### PR TITLE
feat: authenticate with access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ if err != nil {
 }
 ```
 
+Authenticate with an Access Token
+- Implement your own OAuth flow and use the resulting `access_token` in the response
+
+```go
+sf, sfErr := salesforce.Init(salesforce.Creds{
+    Domain:      DOMAIN,
+    AccessToken: ACCESS_TOKEN,
+})
+if err != nil {
+    panic(err)
+}
+```
+
+
 ## SOQL
 Query Salesforce records
 - [Review Salesforce REST API resources for queries](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_query.htm)

--- a/salesforce.go
+++ b/salesforce.go
@@ -192,14 +192,6 @@ func Init(creds Creds) (*Salesforce, error) {
 	var auth *authentication
 	var err error
 	if creds != (Creds{}) && creds.Domain != "" && creds.ConsumerKey != "" && creds.ConsumerSecret != "" &&
-		(creds.Username == "" || creds.Password == "" || creds.SecurityToken == "") {
-
-		auth, err = clientCredentialsFlow(
-			creds.Domain,
-			creds.ConsumerKey,
-			creds.ConsumerSecret,
-		)
-	} else if creds != (Creds{}) && creds.Domain != "" && creds.ConsumerKey != "" && creds.ConsumerSecret != "" &&
 		creds.Username != "" && creds.Password != "" && creds.SecurityToken != "" {
 
 		auth, err = usernamePasswordFlow(
@@ -209,6 +201,17 @@ func Init(creds Creds) (*Salesforce, error) {
 			creds.SecurityToken,
 			creds.ConsumerKey,
 			creds.ConsumerSecret,
+		)
+	} else if creds != (Creds{}) && creds.Domain != "" && creds.ConsumerKey != "" && creds.ConsumerSecret != "" {
+		auth, err = clientCredentialsFlow(
+			creds.Domain,
+			creds.ConsumerKey,
+			creds.ConsumerSecret,
+		)
+	} else if creds != (Creds{}) && creds.AccessToken != "" {
+		auth, err = setAccessToken(
+			creds.Domain,
+			creds.AccessToken,
 		)
 	}
 

--- a/salesforce_test.go
+++ b/salesforce_test.go
@@ -378,6 +378,24 @@ func TestInit(t *testing.T) {
 			want:    &Salesforce{auth: &sfAuth},
 			wantErr: false,
 		},
+		{
+			name: "authentication_client_credentials",
+			args: args{creds: Creds{
+				Domain:         server.URL,
+				ConsumerKey:    "key",
+				ConsumerSecret: "secret",
+			}},
+			want:    &Salesforce{auth: &sfAuth},
+			wantErr: false,
+		},
+		{
+			name: "authentication_access_token",
+			args: args{creds: Creds{
+				Domain:      server.URL,
+				AccessToken: "1234",
+			}},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -386,7 +404,7 @@ func TestInit(t *testing.T) {
 				t.Errorf("Init() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
+			if tt.want != nil && !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Init() = %v, want %v", *got.auth, *tt.want.auth)
 			}
 		})


### PR DESCRIPTION
- a successful response from a OAauth2 call will contain an `access_token` in the response
- use this access token to authenticate in go-salesforce, so that users can implement their own authentication methods