### PR TITLE
fix: major version upgrade in go.mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A REST API wrapper for interacting with Salesforce using the Go programming lang
 ## Installation
 
 ```
-go get github.com/k-capehart/go-salesforce
+go get github.com/k-capehart/go-salesforce/v2
 ```
 
 ## Types

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/k-capehart/go-salesforce
+module github.com/k-capehart/go-salesforce/v2
 
 go 1.22.0
 


### PR DESCRIPTION
go.mod must be updated for major version upgrades past v0 and v1

https://go.dev/wiki/Modules#what-are-some-implications-of-tagging-my-project-with-major-version-v0-v1-or-making-breaking-changes-with-v2