### PR TITLE
Refresh when Invalid Session error occurs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Returns a new Salesforce instance given a user's credentials.
 - `creds`: a struct containing the necessary credentials to authenticate into a Salesforce org
 - [Creating a Connected App in Salesforce](https://help.salesforce.com/s/articleView?id=sf.connected_app_create.htm&type=5)
 - [Review Salesforce oauth flows](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_flows.htm&type=5)
+- If an operation fails with the Error Code `INVALID_SESSION_ID`, go-salesforce will attempt to refresh the session by resubmitting the same credentials used during initialization
 
 [Client Credentials Flow](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_client_credentials_flow.htm&type=5)
 
@@ -655,7 +656,7 @@ Create Bulk API Jobs to query, insert, update, upsert, and delete large collecti
 
 - [Review Salesforce REST API resources for Bulk v2](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/bulk_api_2_0.htm)
 - Work with large lists of records by passing either a slice or records or the path to a csv file
-- Jobs can run asynchronously and optionally wait for them to finish so errors are available
+- Jobs can run asynchronously or synchronously
 
 ### QueryBulkExport
 
@@ -716,7 +717,7 @@ Inserts a list of salesforce records using Bulk API v2, returning a list of Job 
 - `sObjectName`: API name of Salesforce object
 - `records`: a slice of salesforce records
 - `batchSize`: `1 <= batchSize <= 10000`
-- `waitForResults`: denotes whether to wait for jobs to finish and return any errors if they are encountered during the operation
+- `waitForResults`: denotes whether to wait for jobs to finish
 
 ```go
 type Contact struct {
@@ -748,7 +749,7 @@ Inserts a collection of salesforce records from a csv file using Bulk API v2, re
 - `sObjectName`: API name of Salesforce object
 - `filePath`: path to a csv file containing salesforce data
 - `batchSize`: `1 <= batchSize <= 10000`
-- `waitForResults`: denotes whether to wait for jobs to finish and return any errors if they are encountered during the operation
+- `waitForResults`: denotes whether to wait for jobs to finish
 
 `data/avengers.csv`
 
@@ -776,7 +777,7 @@ Updates a list of salesforce records using Bulk API v2, returning a list of Job 
 - `records`: a slice of salesforce records
   - An Id is required
 - `batchSize`: `1 <= batchSize <= 10000`
-- `waitForResults`: denotes whether to wait for jobs to finish and return any errors if they are encountered during the operation
+- `waitForResults`: denotes whether to wait for jobs to finish
 
 ```go
 type Contact struct {
@@ -812,7 +813,7 @@ Updates a collection of salesforce records from a csv file using Bulk API v2, re
 - `filePath`: path to a csv file containing salesforce data
   - An Id is required within csv data
 - `batchSize`: `1 <= batchSize <= 10000`
-- `waitForResults`: denotes whether to wait for jobs to finish and return any errors if they are encountered during the operation
+- `waitForResults`: denotes whether to wait for jobs to finish
 
 `data/update_avengers.csv`
 
@@ -844,7 +845,7 @@ Updates (or inserts) a list of salesforce records using Bulk API v2, returning a
 - `records`: a slice of salesforce records
   - A value for the External Id is required
 - `batchSize`: `1 <= batchSize <= 10000`
-- `waitForResults`: denotes whether to wait for jobs to finish and return any errors if they are encountered during the operation
+- `waitForResults`: denotes whether to wait for jobs to finish
 
 ```go
 type ContactWithExternalId struct {
@@ -881,7 +882,7 @@ Updates (or inserts) a collection of salesforce records from a csv file using Bu
 - `filePath`: path to a csv file containing salesforce data
   - A value for the External Id is required within csv data
 - `batchSize`: `1 <= batchSize <= 10000`
-- `waitForResults`: denotes whether to wait for jobs to finish and return any errors if they are encountered during the operation
+- `waitForResults`: denotes whether to wait for jobs to finish
 
 `data/upsert_avengers.csv`
 
@@ -910,7 +911,7 @@ Deletes a list of salesforce records using Bulk API v2, returning a list of Job 
 - `records`: a slice of salesforce records
   - should only contain Ids
 - `batchSize`: `1 <= batchSize <= 10000`
-- `waitForResults`: denotes whether to wait for jobs to finish and return any errors if they are encountered during the operation
+- `waitForResults`: denotes whether to wait for jobs to finish
 
 ```go
 type Contact struct {
@@ -943,7 +944,7 @@ Deletes a collection of salesforce records from a csv file using Bulk API v2, re
 - `filePath`: path to a csv file containing salesforce data
   - should only contain Ids
 - `batchSize`: `1 <= batchSize <= 10000`
-- `waitForResults`: denotes whether to wait for jobs to finish and return any errors if they are encountered during the operation
+- `waitForResults`: denotes whether to wait for jobs to finish
 
 `data/delete_avengers.csv`
 

--- a/auth.go
+++ b/auth.go
@@ -67,13 +67,13 @@ func refreshSession(auth *authentication) error {
 	switch grantType := auth.grantType; grantType {
 	case grantTypeClientCredentials:
 		refreshedAuth, err = clientCredentialsFlow(
-			auth.creds.Domain,
+			auth.InstanceUrl,
 			auth.creds.ConsumerKey,
 			auth.creds.ConsumerSecret,
 		)
 	case grantTypeUsernamePassword:
 		refreshedAuth, err = usernamePasswordFlow(
-			auth.creds.Domain,
+			auth.InstanceUrl,
 			auth.creds.Username,
 			auth.creds.Password,
 			auth.creds.SecurityToken,
@@ -89,8 +89,7 @@ func refreshSession(auth *authentication) error {
 	}
 
 	if refreshedAuth == nil {
-			// just a suggestion here
-			return errors.New("missing refresh auth")
+		return errors.New("missing refresh auth")
 	}
 
 	auth.AccessToken = refreshedAuth.AccessToken

--- a/auth.go
+++ b/auth.go
@@ -17,6 +17,8 @@ type authentication struct {
 	Scope       string `json:"scope"`
 	IssuedAt    string `json:"issued_at"`
 	Signature   string `json:"signature"`
+	grantType   string
+	creds       Creds
 }
 
 type Creds struct {
@@ -30,8 +32,9 @@ type Creds struct {
 }
 
 const (
-	grantTypePassword          = "password"
+	grantTypeUsernamePassword  = "password"
 	grantTypeClientCredentials = "client_credentials"
+	grantTypeAccessToken       = "access_token"
 )
 
 func validateAuth(sf Salesforce) error {
@@ -45,12 +48,50 @@ func validateSession(auth authentication) error {
 	if err := validateAuth(Salesforce{auth: &auth}); err != nil {
 		return err
 	}
-	_, err := doRequest(http.MethodGet, "/limits", jsonType, auth, "")
+	_, err := doRequest(&auth, requestPayload{
+		method:  http.MethodGet,
+		uri:     "/limits",
+		content: jsonType,
+	})
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func refreshSession(auth *authentication) error {
+	var refreshedAuth *authentication
+	var err error
+
+	switch grantType := auth.grantType; grantType {
+	case grantTypeClientCredentials:
+		refreshedAuth, err = clientCredentialsFlow(
+			auth.creds.Domain,
+			auth.creds.ConsumerKey,
+			auth.creds.ConsumerSecret,
+		)
+	case grantTypeUsernamePassword:
+		refreshedAuth, err = usernamePasswordFlow(
+			auth.creds.Domain,
+			auth.creds.Username,
+			auth.creds.Password,
+			auth.creds.SecurityToken,
+			auth.creds.ConsumerKey,
+			auth.creds.ConsumerSecret,
+		)
+	default:
+		return errors.New("invalid session, unable to refresh session")
+	}
+
+	if refreshedAuth != nil {
+		auth.AccessToken = refreshedAuth.AccessToken
+		auth.IssuedAt = refreshedAuth.IssuedAt
+		auth.Signature = refreshedAuth.Signature
+		auth.Id = refreshedAuth.Id
+	}
+
+	return err
 }
 
 func doAuth(url string, body *strings.Reader) (*authentication, error) {
@@ -79,7 +120,7 @@ func doAuth(url string, body *strings.Reader) (*authentication, error) {
 
 func usernamePasswordFlow(domain string, username string, password string, securityToken string, consumerKey string, consumerSecret string) (*authentication, error) {
 	payload := url.Values{
-		"grant_type":    {grantTypePassword},
+		"grant_type":    {grantTypeUsernamePassword},
 		"client_id":     {consumerKey},
 		"client_secret": {consumerSecret},
 		"username":      {username},
@@ -91,6 +132,7 @@ func usernamePasswordFlow(domain string, username string, password string, secur
 	if err != nil {
 		return nil, err
 	}
+	auth.grantType = grantTypeUsernamePassword
 	return auth, nil
 }
 
@@ -106,6 +148,7 @@ func clientCredentialsFlow(domain string, consumerKey string, consumerSecret str
 	if err != nil {
 		return nil, err
 	}
+	auth.grantType = grantTypeClientCredentials
 	return auth, nil
 }
 
@@ -114,5 +157,6 @@ func setAccessToken(domain string, accessToken string) (*authentication, error) 
 	if err := validateSession(*auth); err != nil {
 		return nil, err
 	}
+	auth.grantType = grantTypeAccessToken
 	return auth, nil
 }

--- a/auth.go
+++ b/auth.go
@@ -84,14 +84,21 @@ func refreshSession(auth *authentication) error {
 		return errors.New("invalid session, unable to refresh session")
 	}
 
-	if refreshedAuth != nil {
-		auth.AccessToken = refreshedAuth.AccessToken
-		auth.IssuedAt = refreshedAuth.IssuedAt
-		auth.Signature = refreshedAuth.Signature
-		auth.Id = refreshedAuth.Id
+	if err != nil {
+		return err
 	}
 
-	return err
+	if refreshedAuth == nil {
+			// just a suggestion here
+			return errors.New("missing refresh auth")
+	}
+
+	auth.AccessToken = refreshedAuth.AccessToken
+	auth.IssuedAt = refreshedAuth.IssuedAt
+	auth.Signature = refreshedAuth.Signature
+	auth.Id = refreshedAuth.Id
+
+	return nil
 }
 
 func doAuth(url string, body *strings.Reader) (*authentication, error) {

--- a/auth_test.go
+++ b/auth_test.go
@@ -48,6 +48,7 @@ func Test_usernamePasswordFlow(t *testing.T) {
 		Id:          "123abc",
 		IssuedAt:    "01/01/1970",
 		Signature:   "signed",
+		grantType:   grantTypeUsernamePassword,
 	}
 	server, _ := setupTestServer(auth, http.StatusOK)
 	defer server.Close()
@@ -117,6 +118,7 @@ func Test_clientCredentialsFlow(t *testing.T) {
 		Id:          "123abc",
 		IssuedAt:    "01/01/1970",
 		Signature:   "signed",
+		grantType:   grantTypeClientCredentials,
 	}
 	server, _ := setupTestServer(auth, http.StatusOK)
 	defer server.Close()

--- a/auth_test.go
+++ b/auth_test.go
@@ -235,3 +235,73 @@ func Test_setAccessToken(t *testing.T) {
 		})
 	}
 }
+
+func Test_refreshSession(t *testing.T) {
+	refreshedAuth := authentication{
+		AccessToken: "1234",
+		InstanceUrl: "example.com",
+		Id:          "123abc",
+		IssuedAt:    "01/01/1970",
+		Signature:   "signed",
+	}
+	serverClientCredentials, sfAuthClientCredentials := setupTestServer(refreshedAuth, http.StatusOK)
+	defer serverClientCredentials.Close()
+	sfAuthClientCredentials.grantType = grantTypeClientCredentials
+
+	serverUserNamePassword, sfAuthUserNamePassword := setupTestServer(refreshedAuth, http.StatusOK)
+	defer serverUserNamePassword.Close()
+	sfAuthUserNamePassword.grantType = grantTypeUsernamePassword
+
+	serverNoGrantType, sfAuthNoGrantType := setupTestServer(refreshedAuth, http.StatusOK)
+	defer serverNoGrantType.Close()
+
+	serverBadRequest, sfAuthBadRequest := setupTestServer("", http.StatusBadGateway)
+	defer serverBadRequest.Close()
+	sfAuthBadRequest.grantType = grantTypeClientCredentials
+
+	serverNoRefresh, sfAuthNoRefresh := setupTestServer("", http.StatusOK)
+	defer serverNoRefresh.Close()
+	sfAuthNoRefresh.grantType = grantTypeClientCredentials
+
+	type args struct {
+		auth *authentication
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name:    "refresh_client_credentials",
+			args:    args{auth: &sfAuthClientCredentials},
+			wantErr: false,
+		},
+		{
+			name:    "refresh_username_password",
+			args:    args{auth: &sfAuthUserNamePassword},
+			wantErr: false,
+		},
+		{
+			name:    "error_no_grant_type",
+			args:    args{auth: &sfAuthNoGrantType},
+			wantErr: true,
+		},
+		{
+			name:    "error_bad_request",
+			args:    args{auth: &sfAuthBadRequest},
+			wantErr: true,
+		},
+		{
+			name:    "no_refresh",
+			args:    args{auth: &sfAuthNoRefresh},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := refreshSession(tt.args.auth); (err != nil) != tt.wantErr {
+				t.Errorf("refreshSession() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/bulk_test.go
+++ b/bulk_test.go
@@ -47,7 +47,7 @@ func Test_createBulkJob(t *testing.T) {
 	queryBody, _ := json.Marshal(queryJobReq)
 
 	type args struct {
-		auth    authentication
+		auth    *authentication
 		jobType string
 		body    []byte
 	}
@@ -60,7 +60,7 @@ func Test_createBulkJob(t *testing.T) {
 		{
 			name: "create_bulk_ingest_job",
 			args: args{
-				auth:    sfAuth,
+				auth:    &sfAuth,
 				jobType: ingestJobType,
 				body:    ingestBody,
 			},
@@ -70,7 +70,7 @@ func Test_createBulkJob(t *testing.T) {
 		{
 			name: "create_bulk_query_job",
 			args: args{
-				auth:    sfAuth,
+				auth:    &sfAuth,
 				jobType: queryJobType,
 				body:    queryBody,
 			},
@@ -80,7 +80,7 @@ func Test_createBulkJob(t *testing.T) {
 		{
 			name: "bad_response",
 			args: args{
-				auth:    badRespSfAuth,
+				auth:    &badRespSfAuth,
 				jobType: queryJobType,
 				body:    queryBody,
 			},
@@ -118,7 +118,7 @@ func Test_getJobResults(t *testing.T) {
 	defer badRespServer.Close()
 
 	type args struct {
-		auth      authentication
+		auth      *authentication
 		jobType   string
 		bulkJobId string
 	}
@@ -131,7 +131,7 @@ func Test_getJobResults(t *testing.T) {
 		{
 			name: "get_job_results",
 			args: args{
-				auth:      sfAuth,
+				auth:      &sfAuth,
 				jobType:   ingestJobType,
 				bulkJobId: "1234",
 			},
@@ -141,7 +141,7 @@ func Test_getJobResults(t *testing.T) {
 		{
 			name: "bad_request",
 			args: args{
-				auth:      badReqSfAuth,
+				auth:      &badReqSfAuth,
 				jobType:   ingestJobType,
 				bulkJobId: "1234",
 			},
@@ -150,7 +150,7 @@ func Test_getJobResults(t *testing.T) {
 		{
 			name: "bad_response",
 			args: args{
-				auth:      badRespSfAuth,
+				auth:      &badRespSfAuth,
 				jobType:   ingestJobType,
 				bulkJobId: "1234",
 			},
@@ -267,7 +267,7 @@ func Test_getQueryJobResults(t *testing.T) {
 	defer badServer.Close()
 
 	type args struct {
-		auth      authentication
+		auth      *authentication
 		bulkJobId string
 		locator   string
 	}
@@ -280,7 +280,7 @@ func Test_getQueryJobResults(t *testing.T) {
 		{
 			name: "get_single_query_job_result",
 			args: args{
-				auth:      sfAuth,
+				auth:      &sfAuth,
 				bulkJobId: "1234",
 				locator:   "",
 			},
@@ -294,7 +294,7 @@ func Test_getQueryJobResults(t *testing.T) {
 		{
 			name: "bad_request",
 			args: args{
-				auth:      badSfAuth,
+				auth:      &badSfAuth,
 				bulkJobId: "1234",
 				locator:   "",
 			},
@@ -395,7 +395,7 @@ func Test_constructBulkJobRequest(t *testing.T) {
 	defer badReqServer.Close()
 
 	type args struct {
-		auth        authentication
+		auth        *authentication
 		sObjectName string
 		operation   string
 		fieldName   string
@@ -409,7 +409,7 @@ func Test_constructBulkJobRequest(t *testing.T) {
 		{
 			name: "construct_bulk_job_success",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				operation:   insertOperation,
 				fieldName:   "",
@@ -420,7 +420,7 @@ func Test_constructBulkJobRequest(t *testing.T) {
 		{
 			name: "construct_bulk_job_fail",
 			args: args{
-				auth:        badJobSfAuth,
+				auth:        &badJobSfAuth,
 				sObjectName: "Account",
 				operation:   insertOperation,
 				fieldName:   "",
@@ -431,7 +431,7 @@ func Test_constructBulkJobRequest(t *testing.T) {
 		{
 			name: "bad_request",
 			args: args{
-				auth:        badReqSfAuth,
+				auth:        &badReqSfAuth,
 				sObjectName: "Account",
 				operation:   insertOperation,
 				fieldName:   "",
@@ -442,7 +442,7 @@ func Test_constructBulkJobRequest(t *testing.T) {
 		{
 			name: "bad_response",
 			args: args{
-				auth:        authentication{},
+				auth:        &authentication{},
 				sObjectName: "Account",
 				operation:   insertOperation,
 				fieldName:   "",
@@ -524,7 +524,7 @@ func Test_doBulkJob(t *testing.T) {
 	}
 
 	type args struct {
-		auth           authentication
+		auth           *authentication
 		sObjectName    string
 		fieldName      string
 		operation      string
@@ -541,7 +541,7 @@ func Test_doBulkJob(t *testing.T) {
 		{
 			name: "bulk_insert_batch_size_200",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				fieldName:   "",
 				operation:   insertOperation,
@@ -562,7 +562,7 @@ func Test_doBulkJob(t *testing.T) {
 		{
 			name: "bulk_upsert_batch_size_1",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				fieldName:   "externalId",
 				operation:   upsertOperation,
@@ -585,7 +585,7 @@ func Test_doBulkJob(t *testing.T) {
 		{
 			name: "bad_request",
 			args: args{
-				auth:        badReqSfAuth,
+				auth:        &badReqSfAuth,
 				sObjectName: "Account",
 				fieldName:   "externalId",
 				operation:   upsertOperation,
@@ -603,7 +603,7 @@ func Test_doBulkJob(t *testing.T) {
 		{
 			name: "bulk_insert_wait_for_results",
 			args: args{
-				auth:        waitingSfAuth,
+				auth:        &waitingSfAuth,
 				sObjectName: "Account",
 				fieldName:   "",
 				operation:   insertOperation,
@@ -621,7 +621,7 @@ func Test_doBulkJob(t *testing.T) {
 		{
 			name: "bad_request_upload_fail",
 			args: args{
-				auth:        uploadFailSfAuth,
+				auth:        &uploadFailSfAuth,
 				sObjectName: "Account",
 				fieldName:   "",
 				operation:   insertOperation,
@@ -639,7 +639,7 @@ func Test_doBulkJob(t *testing.T) {
 		{
 			name: "bad_data",
 			args: args{
-				auth:           sfAuth,
+				auth:           &sfAuth,
 				sObjectName:    "Account",
 				fieldName:      "",
 				operation:      insertOperation,
@@ -677,7 +677,7 @@ func Test_waitForJobResultsAsync(t *testing.T) {
 	defer badServer.Close()
 
 	type args struct {
-		auth      authentication
+		auth      *authentication
 		bulkJobId string
 		jobType   string
 		interval  time.Duration
@@ -691,7 +691,7 @@ func Test_waitForJobResultsAsync(t *testing.T) {
 		{
 			name: "wait_for_ingest_result",
 			args: args{
-				auth:      sfAuth,
+				auth:      &sfAuth,
 				bulkJobId: "1234",
 				jobType:   ingestJobType,
 				interval:  time.Nanosecond,
@@ -702,7 +702,7 @@ func Test_waitForJobResultsAsync(t *testing.T) {
 		{
 			name: "wait_for_query_result",
 			args: args{
-				auth:      sfAuth,
+				auth:      &sfAuth,
 				bulkJobId: "1234",
 				jobType:   queryJobType,
 				interval:  time.Nanosecond,
@@ -713,7 +713,7 @@ func Test_waitForJobResultsAsync(t *testing.T) {
 		{
 			name: "bad_request",
 			args: args{
-				auth:      badSfAuth,
+				auth:      &badSfAuth,
 				bulkJobId: "",
 				jobType:   queryJobType,
 				interval:  time.Nanosecond,
@@ -745,7 +745,7 @@ func Test_waitForJobResults(t *testing.T) {
 	defer badServer.Close()
 
 	type args struct {
-		auth      authentication
+		auth      *authentication
 		bulkJobId string
 		jobType   string
 		interval  time.Duration
@@ -759,7 +759,7 @@ func Test_waitForJobResults(t *testing.T) {
 		{
 			name: "wait_for_ingest_result",
 			args: args{
-				auth:      sfAuth,
+				auth:      &sfAuth,
 				bulkJobId: "1234",
 				jobType:   ingestJobType,
 				interval:  time.Nanosecond,
@@ -769,7 +769,7 @@ func Test_waitForJobResults(t *testing.T) {
 		{
 			name: "wait_for_query_result",
 			args: args{
-				auth:      sfAuth,
+				auth:      &sfAuth,
 				bulkJobId: "1234",
 				jobType:   queryJobType,
 				interval:  time.Nanosecond,
@@ -779,7 +779,7 @@ func Test_waitForJobResults(t *testing.T) {
 		{
 			name: "bad_request",
 			args: args{
-				auth:      badSfAuth,
+				auth:      &badSfAuth,
 				bulkJobId: "",
 				jobType:   queryJobType,
 				interval:  time.Nanosecond,
@@ -820,7 +820,7 @@ func Test_collectQueryResults(t *testing.T) {
 	defer badServer.Close()
 
 	type args struct {
-		auth      authentication
+		auth      *authentication
 		bulkJobId string
 	}
 	tests := []struct {
@@ -832,7 +832,7 @@ func Test_collectQueryResults(t *testing.T) {
 		{
 			name: "query_with_locator",
 			args: args{
-				auth:      sfAuth,
+				auth:      &sfAuth,
 				bulkJobId: "123",
 			},
 			want:    [][]string{{"col"}, {"row"}, {"row"}},
@@ -841,7 +841,7 @@ func Test_collectQueryResults(t *testing.T) {
 		{
 			name: "bad_request",
 			args: args{
-				auth:      badSfAuth,
+				auth:      &badSfAuth,
 				bulkJobId: "123",
 			},
 			wantErr: true,
@@ -891,7 +891,7 @@ func Test_uploadJobData(t *testing.T) {
 	defer badRequestServer.Close()
 
 	type args struct {
-		auth    authentication
+		auth    *authentication
 		data    string
 		bulkJob bulkJob
 	}
@@ -903,7 +903,7 @@ func Test_uploadJobData(t *testing.T) {
 		{
 			name: "update_job_state_success",
 			args: args{
-				auth:    sfAuth,
+				auth:    &sfAuth,
 				data:    "data",
 				bulkJob: bulkJob{},
 			},
@@ -912,7 +912,7 @@ func Test_uploadJobData(t *testing.T) {
 		{
 			name: "batch_req_fail",
 			args: args{
-				auth:    badBatchReqAuth,
+				auth:    &badBatchReqAuth,
 				data:    "data",
 				bulkJob: bulkJob{},
 			},
@@ -921,7 +921,7 @@ func Test_uploadJobData(t *testing.T) {
 		{
 			name: "update_job_state_fail_aborted",
 			args: args{
-				auth:    badBatchAndUpdateJobStateReqAuth,
+				auth:    &badBatchAndUpdateJobStateReqAuth,
 				data:    "data",
 				bulkJob: bulkJob{},
 			},
@@ -930,7 +930,7 @@ func Test_uploadJobData(t *testing.T) {
 		{
 			name: "update_job_state_fail_complete",
 			args: args{
-				auth:    badRequestSfAuth,
+				auth:    &badRequestSfAuth,
 				data:    "data",
 				bulkJob: bulkJob{},
 			},
@@ -1042,7 +1042,7 @@ func Test_updateJobState(t *testing.T) {
 	type args struct {
 		job   bulkJob
 		state string
-		auth  authentication
+		auth  *authentication
 	}
 	tests := []struct {
 		name    string
@@ -1054,7 +1054,7 @@ func Test_updateJobState(t *testing.T) {
 			args: args{
 				job:   bulkJob{},
 				state: "",
-				auth:  badSfAuth,
+				auth:  &badSfAuth,
 			},
 			wantErr: true,
 		},
@@ -1131,7 +1131,7 @@ func Test_doBulkJobWithFile(t *testing.T) {
 	}
 
 	type args struct {
-		auth           authentication
+		auth           *authentication
 		sObjectName    string
 		fieldName      string
 		operation      string
@@ -1148,7 +1148,7 @@ func Test_doBulkJobWithFile(t *testing.T) {
 		{
 			name: "bulk_insert_batch_size_200",
 			args: args{
-				auth:           sfAuth,
+				auth:           &sfAuth,
 				sObjectName:    "Account",
 				fieldName:      "",
 				operation:      insertOperation,
@@ -1162,7 +1162,7 @@ func Test_doBulkJobWithFile(t *testing.T) {
 		{
 			name: "bulk_insert_batch_size_1",
 			args: args{
-				auth:           sfAuth,
+				auth:           &sfAuth,
 				sObjectName:    "Account",
 				fieldName:      "",
 				operation:      insertOperation,
@@ -1176,7 +1176,7 @@ func Test_doBulkJobWithFile(t *testing.T) {
 		{
 			name: "bad_request",
 			args: args{
-				auth:           badReqSfAuth,
+				auth:           &badReqSfAuth,
 				sObjectName:    "Account",
 				fieldName:      "externalId",
 				operation:      upsertOperation,
@@ -1189,7 +1189,7 @@ func Test_doBulkJobWithFile(t *testing.T) {
 		{
 			name: "bulk_insert_wait_for_results",
 			args: args{
-				auth:           waitingSfAuth,
+				auth:           &waitingSfAuth,
 				sObjectName:    "Account",
 				fieldName:      "",
 				operation:      insertOperation,
@@ -1203,7 +1203,7 @@ func Test_doBulkJobWithFile(t *testing.T) {
 		{
 			name: "bad_request_upload_fail",
 			args: args{
-				auth:           uploadFailSfAuth,
+				auth:           &uploadFailSfAuth,
 				sObjectName:    "Account",
 				fieldName:      "",
 				operation:      insertOperation,
@@ -1272,7 +1272,7 @@ func Test_doQueryBulk(t *testing.T) {
 	}
 
 	type args struct {
-		auth     authentication
+		auth     *authentication
 		filePath string
 		query    string
 	}
@@ -1284,7 +1284,7 @@ func Test_doQueryBulk(t *testing.T) {
 		{
 			name: "bad_job_creation",
 			args: args{
-				auth:     badJobCreationSfAuth,
+				auth:     &badJobCreationSfAuth,
 				filePath: "data/data.csv",
 				query:    "SELECT Id FROM Account",
 			},
@@ -1293,7 +1293,7 @@ func Test_doQueryBulk(t *testing.T) {
 		{
 			name: "get_results_fail",
 			args: args{
-				auth:     badResultsSfAuth,
+				auth:     &badResultsSfAuth,
 				filePath: "data/data.csv",
 				query:    "SELECT Id FROM Account",
 			},
@@ -1341,7 +1341,7 @@ func Test_getJobRecordResults(t *testing.T) {
 	defer successThenFailServer.Close()
 
 	type args struct {
-		auth           authentication
+		auth           *authentication
 		bulkJobResults BulkJobResults
 	}
 	tests := []struct {
@@ -1353,7 +1353,7 @@ func Test_getJobRecordResults(t *testing.T) {
 		{
 			name: "successful_get_job_record_results",
 			args: args{
-				auth:           sfAuth,
+				auth:           &sfAuth,
 				bulkJobResults: BulkJobResults{Id: "1234"},
 			},
 			want: BulkJobResults{
@@ -1370,7 +1370,7 @@ func Test_getJobRecordResults(t *testing.T) {
 		{
 			name: "failed_to_get_successful_records",
 			args: args{
-				auth:           badRequestAuth,
+				auth:           &badRequestAuth,
 				bulkJobResults: BulkJobResults{Id: "1234"},
 			},
 			want:    BulkJobResults{Id: "1234"},
@@ -1379,7 +1379,7 @@ func Test_getJobRecordResults(t *testing.T) {
 		{
 			name: "failed_to_get_failed_records",
 			args: args{
-				auth:           successThenFailAuth,
+				auth:           &successThenFailAuth,
 				bulkJobResults: BulkJobResults{Id: "1234"},
 			},
 			want: BulkJobResults{
@@ -1433,7 +1433,7 @@ func Test_getBulkJobRecords(t *testing.T) {
 	defer badDataServer.Close()
 
 	type args struct {
-		auth       authentication
+		auth       *authentication
 		bulkJobId  string
 		resultType string
 	}
@@ -1446,7 +1446,7 @@ func Test_getBulkJobRecords(t *testing.T) {
 		{
 			name: "successful_get_failed_job_records",
 			args: args{
-				auth:       sfAuth,
+				auth:       &sfAuth,
 				bulkJobId:  "1234",
 				resultType: failedResults,
 			},
@@ -1458,7 +1458,7 @@ func Test_getBulkJobRecords(t *testing.T) {
 		{
 			name: "failed_bad_request",
 			args: args{
-				auth:       badReqAuth,
+				auth:       &badReqAuth,
 				bulkJobId:  "1234",
 				resultType: failedResults,
 			},
@@ -1468,7 +1468,7 @@ func Test_getBulkJobRecords(t *testing.T) {
 		{
 			name: "failed_conversion",
 			args: args{
-				auth:       badDataAuth,
+				auth:       &badDataAuth,
 				bulkJobId:  "1234",
 				resultType: failedResults,
 			},

--- a/composite.go
+++ b/composite.go
@@ -33,12 +33,17 @@ type compositeSubRequestResult struct {
 	ReferenceId    string             `json:"referenceId"`
 }
 
-func doCompositeRequest(auth authentication, compReq compositeRequest) (SalesforceResults, error) {
+func doCompositeRequest(auth *authentication, compReq compositeRequest) (SalesforceResults, error) {
 	body, jsonErr := json.Marshal(compReq)
 	if jsonErr != nil {
 		return SalesforceResults{}, jsonErr
 	}
-	resp, httpErr := doRequest(http.MethodPost, "/composite", jsonType, auth, string(body))
+	resp, httpErr := doRequest(auth, requestPayload{
+		method:  http.MethodPost,
+		uri:     "/composite",
+		content: jsonType,
+		body:    string(body),
+	})
 	if httpErr != nil {
 		return SalesforceResults{}, httpErr
 	}
@@ -122,7 +127,7 @@ func processCompositeResponse(resp http.Response, allOrNone bool) (SalesforceRes
 	return results, nil
 }
 
-func doInsertComposite(auth authentication, sObjectName string, records any, allOrNone bool, batchSize int) (SalesforceResults, error) {
+func doInsertComposite(auth *authentication, sObjectName string, records any, allOrNone bool, batchSize int) (SalesforceResults, error) {
 	recordMap, err := convertToSliceOfMaps(records)
 	if err != nil {
 		return SalesforceResults{}, err
@@ -146,7 +151,7 @@ func doInsertComposite(auth authentication, sObjectName string, records any, all
 	return results, nil
 }
 
-func doUpdateComposite(auth authentication, sObjectName string, records any, allOrNone bool, batchSize int) (SalesforceResults, error) {
+func doUpdateComposite(auth *authentication, sObjectName string, records any, allOrNone bool, batchSize int) (SalesforceResults, error) {
 	recordMap, err := convertToSliceOfMaps(records)
 	if err != nil {
 		return SalesforceResults{}, err
@@ -173,7 +178,7 @@ func doUpdateComposite(auth authentication, sObjectName string, records any, all
 	return results, nil
 }
 
-func doUpsertComposite(auth authentication, sObjectName string, fieldName string, records any, allOrNone bool, batchSize int) (SalesforceResults, error) {
+func doUpsertComposite(auth *authentication, sObjectName string, fieldName string, records any, allOrNone bool, batchSize int) (SalesforceResults, error) {
 	recordMap, err := convertToSliceOfMaps(records)
 	if err != nil {
 		return SalesforceResults{}, err
@@ -200,7 +205,7 @@ func doUpsertComposite(auth authentication, sObjectName string, fieldName string
 	return results, nil
 }
 
-func doDeleteComposite(auth authentication, sObjectName string, records any, allOrNone bool, batchSize int) (SalesforceResults, error) {
+func doDeleteComposite(auth *authentication, sObjectName string, records any, allOrNone bool, batchSize int) (SalesforceResults, error) {
 	recordMap, err := convertToSliceOfMaps(records)
 	if err != nil {
 		return SalesforceResults{}, err

--- a/composite_test.go
+++ b/composite_test.go
@@ -306,7 +306,7 @@ func Test_doCompositeRequest(t *testing.T) {
 	}
 
 	type args struct {
-		auth    authentication
+		auth    *authentication
 		compReq compositeRequest
 	}
 	tests := []struct {
@@ -318,7 +318,7 @@ func Test_doCompositeRequest(t *testing.T) {
 		{
 			name: "successful_request",
 			args: args{
-				auth:    sfAuth,
+				auth:    &sfAuth,
 				compReq: compReq,
 			},
 			want: SalesforceResults{
@@ -330,7 +330,7 @@ func Test_doCompositeRequest(t *testing.T) {
 		{
 			name: "bad_request",
 			args: args{
-				auth:    badReqSfAuth,
+				auth:    &badReqSfAuth,
 				compReq: compReq,
 			},
 			want:    SalesforceResults{},
@@ -339,7 +339,7 @@ func Test_doCompositeRequest(t *testing.T) {
 		{
 			name: "salesforce_errors",
 			args: args{
-				auth:    sfErrorSfAuth,
+				auth:    &sfErrorSfAuth,
 				compReq: compReq,
 			},
 			want:    sfResultsFail,
@@ -378,7 +378,7 @@ func Test_doInsertComposite(t *testing.T) {
 	defer server.Close()
 
 	type args struct {
-		auth        authentication
+		auth        *authentication
 		sObjectName string
 		records     any
 		allOrNone   bool
@@ -393,7 +393,7 @@ func Test_doInsertComposite(t *testing.T) {
 		{
 			name: "successful_insert_composite",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				records: []account{
 					{
@@ -415,7 +415,7 @@ func Test_doInsertComposite(t *testing.T) {
 		{
 			name: "bad_data",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				records:     "1",
 				batchSize:   200,
@@ -458,7 +458,7 @@ func Test_doUpdateComposite(t *testing.T) {
 	defer server.Close()
 
 	type args struct {
-		auth        authentication
+		auth        *authentication
 		sObjectName string
 		records     any
 		allOrNone   bool
@@ -473,7 +473,7 @@ func Test_doUpdateComposite(t *testing.T) {
 		{
 			name: "successful_update_composite",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				records: []account{
 					{
@@ -497,7 +497,7 @@ func Test_doUpdateComposite(t *testing.T) {
 		{
 			name: "bad_data",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				records:     "1",
 				batchSize:   200,
@@ -509,7 +509,7 @@ func Test_doUpdateComposite(t *testing.T) {
 		{
 			name: "fail_no_id",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				records: []account{
 					{
@@ -556,7 +556,7 @@ func Test_doUpsertComposite(t *testing.T) {
 	defer server.Close()
 
 	type args struct {
-		auth        authentication
+		auth        *authentication
 		sObjectName string
 		fieldName   string
 		records     any
@@ -572,7 +572,7 @@ func Test_doUpsertComposite(t *testing.T) {
 		{
 			name: "successful_upsert_composite",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				fieldName:   "ExternalId__c",
 				records: []account{
@@ -597,7 +597,7 @@ func Test_doUpsertComposite(t *testing.T) {
 		{
 			name: "bad_data",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				fieldName:   "ExternalId__c",
 				records:     "1",
@@ -610,7 +610,7 @@ func Test_doUpsertComposite(t *testing.T) {
 		{
 			name: "fail_no_external_id",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				fieldName:   "ExternalId__c",
 				records: []account{
@@ -657,7 +657,7 @@ func Test_doDeleteComposite(t *testing.T) {
 	defer server.Close()
 
 	type args struct {
-		auth        authentication
+		auth        *authentication
 		sObjectName string
 		records     any
 		allOrNone   bool
@@ -672,7 +672,7 @@ func Test_doDeleteComposite(t *testing.T) {
 		{
 			name: "successful_delete_composite_single_batch",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				records: []account{
 					{
@@ -694,7 +694,7 @@ func Test_doDeleteComposite(t *testing.T) {
 		{
 			name: "successful_delete_composite_multi_batch",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				records: []account{
 					{
@@ -716,7 +716,7 @@ func Test_doDeleteComposite(t *testing.T) {
 		{
 			name: "bad_data",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				records:     "1",
 				batchSize:   200,
@@ -728,7 +728,7 @@ func Test_doDeleteComposite(t *testing.T) {
 		{
 			name: "fail_no_id",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				records:     []account{{}},
 				batchSize:   200,

--- a/dml_test.go
+++ b/dml_test.go
@@ -200,7 +200,7 @@ func Test_doBatchedRequestsForCollection(t *testing.T) {
 	defer sfErrorServer.Close()
 
 	type args struct {
-		auth      authentication
+		auth      *authentication
 		method    string
 		url       string
 		batchSize int
@@ -215,7 +215,7 @@ func Test_doBatchedRequestsForCollection(t *testing.T) {
 		{
 			name: "single_record",
 			args: args{
-				auth:      sfAuth,
+				auth:      &sfAuth,
 				method:    http.MethodPost,
 				url:       "",
 				batchSize: 200,
@@ -234,7 +234,7 @@ func Test_doBatchedRequestsForCollection(t *testing.T) {
 		{
 			name: "multiple_batches",
 			args: args{
-				auth:      sfAuth,
+				auth:      &sfAuth,
 				method:    http.MethodPost,
 				url:       "",
 				batchSize: 1,
@@ -256,7 +256,7 @@ func Test_doBatchedRequestsForCollection(t *testing.T) {
 		{
 			name: "bad_request",
 			args: args{
-				auth:      badReqSfAuth,
+				auth:      &badReqSfAuth,
 				method:    http.MethodPost,
 				url:       "",
 				batchSize: 1,
@@ -272,7 +272,7 @@ func Test_doBatchedRequestsForCollection(t *testing.T) {
 		{
 			name: "salesforce_error",
 			args: args{
-				auth:      sfErrorSfAuth,
+				auth:      &sfErrorSfAuth,
 				method:    http.MethodPost,
 				url:       "",
 				batchSize: 1,
@@ -320,7 +320,7 @@ func Test_doInsertOne(t *testing.T) {
 	defer badReqServer.Close()
 
 	type args struct {
-		auth        authentication
+		auth        *authentication
 		sObjectName string
 		record      any
 	}
@@ -333,7 +333,7 @@ func Test_doInsertOne(t *testing.T) {
 		{
 			name: "successful_insert",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				record: account{
 					Name: "test account",
@@ -345,7 +345,7 @@ func Test_doInsertOne(t *testing.T) {
 		{
 			name: "bad_request",
 			args: args{
-				auth:        badReqSfAuth,
+				auth:        &badReqSfAuth,
 				sObjectName: "Account",
 				record: account{
 					Name: "test account",
@@ -357,7 +357,7 @@ func Test_doInsertOne(t *testing.T) {
 		{
 			name: "bad_data",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				record:      "1",
 			},
@@ -391,7 +391,7 @@ func Test_doUpdateOne(t *testing.T) {
 	defer badReqServer.Close()
 
 	type args struct {
-		auth        authentication
+		auth        *authentication
 		sObjectName string
 		record      any
 	}
@@ -403,7 +403,7 @@ func Test_doUpdateOne(t *testing.T) {
 		{
 			name: "successful_update",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				record: account{
 					Id:   "1234",
@@ -415,7 +415,7 @@ func Test_doUpdateOne(t *testing.T) {
 		{
 			name: "bad_request",
 			args: args{
-				auth:        badReqSfAuth,
+				auth:        &badReqSfAuth,
 				sObjectName: "Account",
 				record: account{
 					Id:   "1234",
@@ -427,7 +427,7 @@ func Test_doUpdateOne(t *testing.T) {
 		{
 			name: "bad_data",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				record:      "1",
 			},
@@ -462,7 +462,7 @@ func Test_doUpsertOne(t *testing.T) {
 	defer badReqServer.Close()
 
 	type args struct {
-		auth        authentication
+		auth        *authentication
 		sObjectName string
 		fieldName   string
 		record      any
@@ -476,7 +476,7 @@ func Test_doUpsertOne(t *testing.T) {
 		{
 			name: "successful_upsert",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				fieldName:   "ExternalId__c",
 				record: account{
@@ -490,7 +490,7 @@ func Test_doUpsertOne(t *testing.T) {
 		{
 			name: "bad_request",
 			args: args{
-				auth:        badReqSfAuth,
+				auth:        &badReqSfAuth,
 				sObjectName: "Account",
 				fieldName:   "ExternalId__c",
 				record: account{
@@ -504,7 +504,7 @@ func Test_doUpsertOne(t *testing.T) {
 		{
 			name: "bad_data",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				fieldName:   "ExternalId__c",
 				record:      "1",
@@ -538,7 +538,7 @@ func Test_doDeleteOne(t *testing.T) {
 	defer badReqServer.Close()
 
 	type args struct {
-		auth        authentication
+		auth        *authentication
 		sObjectName string
 		record      any
 	}
@@ -550,7 +550,7 @@ func Test_doDeleteOne(t *testing.T) {
 		{
 			name: "successful_delete",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				record: account{
 					Id: "1234",
@@ -561,7 +561,7 @@ func Test_doDeleteOne(t *testing.T) {
 		{
 			name: "bad_request",
 			args: args{
-				auth:        badReqSfAuth,
+				auth:        &badReqSfAuth,
 				sObjectName: "Account",
 				record: account{
 					Id: "1234",
@@ -572,7 +572,7 @@ func Test_doDeleteOne(t *testing.T) {
 		{
 			name: "bad_data",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				record:      "1",
 			},
@@ -606,7 +606,7 @@ func Test_doInsertCollection(t *testing.T) {
 	defer server.Close()
 
 	type args struct {
-		auth        authentication
+		auth        *authentication
 		sObjectName string
 		records     any
 		batchSize   int
@@ -620,7 +620,7 @@ func Test_doInsertCollection(t *testing.T) {
 		{
 			name: "successful_insert_collection",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				records: []account{
 					{
@@ -638,7 +638,7 @@ func Test_doInsertCollection(t *testing.T) {
 		{
 			name: "bad_data",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				records:     "1",
 				batchSize:   200,
@@ -675,7 +675,7 @@ func Test_doUpdateCollection(t *testing.T) {
 	defer server.Close()
 
 	type args struct {
-		auth        authentication
+		auth        *authentication
 		sObjectName string
 		records     any
 		batchSize   int
@@ -689,7 +689,7 @@ func Test_doUpdateCollection(t *testing.T) {
 		{
 			name: "successful_update_collection",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				records: []account{
 					{
@@ -709,7 +709,7 @@ func Test_doUpdateCollection(t *testing.T) {
 		{
 			name: "bad_data",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				records:     "1",
 				batchSize:   200,
@@ -750,7 +750,7 @@ func Test_doUpsertCollection(t *testing.T) {
 	defer server.Close()
 
 	type args struct {
-		auth        authentication
+		auth        *authentication
 		sObjectName string
 		fieldName   string
 		records     any
@@ -765,7 +765,7 @@ func Test_doUpsertCollection(t *testing.T) {
 		{
 			name: "successful_upsert_collection",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				fieldName:   "ExternalId__c",
 				records: []account{
@@ -786,7 +786,7 @@ func Test_doUpsertCollection(t *testing.T) {
 		{
 			name: "bad_data",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				fieldName:   "ExternalId__c",
 				records:     "1",
@@ -862,7 +862,7 @@ func Test_doDeleteCollection(t *testing.T) {
 	defer sfErrorServer.Close()
 
 	type args struct {
-		auth        authentication
+		auth        *authentication
 		sObjectName string
 		records     any
 		batchSize   int
@@ -876,7 +876,7 @@ func Test_doDeleteCollection(t *testing.T) {
 		{
 			name: "successful_delete_collection_single_batch",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				records: []account{
 					{
@@ -894,7 +894,7 @@ func Test_doDeleteCollection(t *testing.T) {
 		{
 			name: "successful_delete_collection_multi_batch",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				records: []account{
 					{
@@ -912,7 +912,7 @@ func Test_doDeleteCollection(t *testing.T) {
 		{
 			name: "bad_data",
 			args: args{
-				auth:        sfAuth,
+				auth:        &sfAuth,
 				sObjectName: "Account",
 				records:     "1",
 				batchSize:   200,
@@ -923,7 +923,7 @@ func Test_doDeleteCollection(t *testing.T) {
 		{
 			name: "bad_request",
 			args: args{
-				auth:        badReqSfAuth,
+				auth:        &badReqSfAuth,
 				sObjectName: "Account",
 				records: []account{
 					{
@@ -938,7 +938,7 @@ func Test_doDeleteCollection(t *testing.T) {
 		{
 			name: "salesforce_errors",
 			args: args{
-				auth:        sfErrorSfAuth,
+				auth:        &sfErrorSfAuth,
 				sObjectName: "Account",
 				records: []account{
 					{

--- a/query.go
+++ b/query.go
@@ -17,7 +17,7 @@ type queryResponse struct {
 	Records        []map[string]any `json:"records"`
 }
 
-func performQuery(auth authentication, query string, sObject any) error {
+func performQuery(auth *authentication, query string, sObject any) error {
 	query = url.QueryEscape(query)
 	queryResp := &queryResponse{
 		Done:           false,
@@ -25,7 +25,11 @@ func performQuery(auth authentication, query string, sObject any) error {
 	}
 
 	for !queryResp.Done {
-		resp, err := doRequest(http.MethodGet, queryResp.NextRecordsUrl, jsonType, auth, "")
+		resp, err := doRequest(auth, requestPayload{
+			method:  http.MethodGet,
+			uri:     queryResp.NextRecordsUrl,
+			content: jsonType,
+		})
 		if err != nil {
 			return err
 		}

--- a/query_test.go
+++ b/query_test.go
@@ -61,7 +61,7 @@ func Test_performQuery(t *testing.T) {
 	defer badRespServer.Close()
 
 	type args struct {
-		auth    authentication
+		auth    *authentication
 		query   string
 		sObject []account
 	}
@@ -74,7 +74,7 @@ func Test_performQuery(t *testing.T) {
 		{
 			name: "query_account",
 			args: args{
-				auth:    sfAuth,
+				auth:    &sfAuth,
 				query:   "SELECT Id, Name FROM Account",
 				sObject: []account{},
 			},
@@ -93,7 +93,7 @@ func Test_performQuery(t *testing.T) {
 		{
 			name: "http_error",
 			args: args{
-				auth:    badSfAuth,
+				auth:    &badSfAuth,
 				query:   "SELECT Id, Name FROM Account",
 				sObject: []account{},
 			},
@@ -103,7 +103,7 @@ func Test_performQuery(t *testing.T) {
 		{
 			name: "bad_response",
 			args: args{
-				auth:    badRespSfAuth,
+				auth:    &badRespSfAuth,
 				query:   "SELECT Id FROM Account",
 				sObject: []account{},
 			},

--- a/salesforce.go
+++ b/salesforce.go
@@ -175,28 +175,28 @@ func validateBulk(sf Salesforce, records any, batchSize int, isFile bool) error 
 func processSalesforceError(resp http.Response, auth *authentication, payload requestPayload) (*http.Response, error) {
 	responseData, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return &resp, err
 	}
 	var sfErrors []SalesforceErrorMessage
 	err = json.Unmarshal(responseData, &sfErrors)
 	if err != nil {
-		return nil, err
+		return &resp, err
 	}
 	for _, sfError := range sfErrors {
 		if sfError.ErrorCode == invalidSessionIdError && !payload.retry { // only attempt to refresh the session once
 			err = refreshSession(auth)
 			if err != nil {
-				return nil, err
+				return &resp, err
 			}
 			newResp, err := doRequest(auth, requestPayload{payload.method, payload.uri, payload.content, payload.body, true})
 			if err != nil {
-				return nil, err
+				return &resp, err
 			}
 			return newResp, nil
 		}
 	}
 
-	return nil, errors.New(string(responseData))
+	return &resp, errors.New(string(responseData))
 }
 
 func Init(creds Creds) (*Salesforce, error) {

--- a/salesforce_test.go
+++ b/salesforce_test.go
@@ -261,8 +261,55 @@ func Test_processSalesforceError(t *testing.T) {
 		Fields:     []string{},
 		ErrorCode:  strconv.Itoa(http.StatusInternalServerError),
 	}})
+	exampleResp := http.Response{
+		Status:     "500",
+		StatusCode: 500,
+		Body:       io.NopCloser(strings.NewReader(string(body))),
+	}
+
 	badServer, badSfAuth := setupTestServer(body, http.StatusInternalServerError)
 	defer badServer.Close()
+
+	bodyInvalidSession, _ := json.Marshal([]SalesforceErrorMessage{{
+		Message:    "error message",
+		StatusCode: strconv.Itoa(http.StatusInternalServerError),
+		Fields:     []string{},
+		ErrorCode:  invalidSessionIdError,
+	}})
+	reqPayload := requestPayload{
+		method:  http.MethodGet,
+		uri:     "",
+		content: jsonType,
+		body:    "",
+	}
+
+	serverRefreshed, sfAuthRefreshed := setupTestServer("", http.StatusOK)
+	defer serverRefreshed.Close()
+	serverInvalidSession, sfAuthInvalidSession := setupTestServer(sfAuthRefreshed, http.StatusOK)
+	defer serverInvalidSession.Close()
+	sfAuthInvalidSession.grantType = grantTypeClientCredentials
+
+	serverRefreshFail, sfAuthRefreshFail := setupTestServer("", http.StatusBadRequest)
+	defer serverRefreshFail.Close()
+	sfAuthRefreshFail.grantType = grantTypeClientCredentials
+
+	serverRetryFail := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.RequestURI, "/oauth2/token") {
+			body, err := json.Marshal(badSfAuth)
+			if err != nil {
+				panic(err)
+			}
+			w.Write(body)
+		} else {
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer serverRetryFail.Close()
+	sfAuthRetryFail := authentication{
+		InstanceUrl: serverRetryFail.URL,
+		AccessToken: "1234",
+		grantType:   grantTypeClientCredentials,
+	}
 
 	type args struct {
 		resp    http.Response
@@ -272,37 +319,71 @@ func Test_processSalesforceError(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    string
+		want    int
 		wantErr bool
 	}{
 		{
 			name: "process_500_error",
 			args: args{
-				resp: http.Response{
-					Status:     "500",
-					StatusCode: 500,
-					Body:       io.NopCloser(strings.NewReader(string(body))),
-				},
-				auth: &badSfAuth,
-				payload: requestPayload{
-					method:  http.MethodGet,
-					uri:     "",
-					content: jsonType,
-					body:    "",
-				},
+				resp:    exampleResp,
+				auth:    &badSfAuth,
+				payload: reqPayload,
 			},
-			want:    string(body),
+			want:    exampleResp.StatusCode,
+			wantErr: true,
+		},
+		{
+			name: "process_invalid_session",
+			args: args{
+				resp: http.Response{
+					Status:     "400",
+					StatusCode: 400,
+					Body:       io.NopCloser(strings.NewReader(string(bodyInvalidSession))),
+				},
+				auth:    &sfAuthInvalidSession,
+				payload: reqPayload,
+			},
+			want:    http.StatusOK,
+			wantErr: false,
+		},
+		{
+			name: "fail_to_refresh",
+			args: args{
+				resp: http.Response{
+					Status:     "400",
+					StatusCode: 400,
+					Body:       io.NopCloser(strings.NewReader(string(bodyInvalidSession))),
+				},
+				auth:    &sfAuthRefreshFail,
+				payload: reqPayload,
+			},
+			want:    400,
+			wantErr: true,
+		},
+		{
+			name: "fail_to_retry_request",
+			args: args{
+				resp: http.Response{
+					Status:     "400",
+					StatusCode: 400,
+					Body:       io.NopCloser(strings.NewReader(string(bodyInvalidSession))),
+				},
+				auth:    &sfAuthRetryFail,
+				payload: reqPayload,
+			},
+			want:    400,
 			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := processSalesforceError(tt.args.resp, tt.args.auth, tt.args.payload)
-			if err != nil != tt.wantErr {
+			got, err := processSalesforceError(tt.args.resp, tt.args.auth, tt.args.payload)
+			if (err != nil) != tt.wantErr {
 				t.Errorf("processSalesforceError() error = %v, wantErr %v", err, tt.wantErr)
+				return
 			}
-			if err.Error() != tt.want {
-				t.Errorf("processSalesforceError() = %v, want %v", err, tt.want)
+			if !reflect.DeepEqual(got.StatusCode, tt.want) {
+				t.Errorf("processSalesforceError() = %v, want %v", got.StatusCode, tt.want)
 			}
 		})
 	}

--- a/salesforce_test.go
+++ b/salesforce_test.go
@@ -299,7 +299,9 @@ func Test_processSalesforceError(t *testing.T) {
 			if err != nil {
 				panic(err)
 			}
-			w.Write(body)
+			if _, err := w.Write(body); err != nil {
+				panic(err)
+			}
 		} else {
 			w.WriteHeader(http.StatusBadRequest)
 		}


### PR DESCRIPTION
- if an operation fails due to an invalid session, attempt to refresh the session by resubmitting credentials
- only attempt to refresh once to avoid entering an endless loop