### PR TITLE
feat: handle 300 response for when multiple matches are found for a single salesforce external id

### DIFF
--- a/README.md
+++ b/README.md
@@ -1032,7 +1032,7 @@ Anyone is welcome to contribute.
 - Open an issue or discussion post to track the effort
 - Fork this repository, then clone it
 - Place this in your own module's `go.mod` to enable testing local changes
-  - `replace github.com/k-capehart/go-salesforce => /path_to_local_fork/`
+  - `replace github.com/k-capehart/go-salesforce/v2 => /path_to_local_fork/`
 - Run tests
   - `go test -cover`
 - Generate code coverage output

--- a/salesforce.go
+++ b/salesforce.go
@@ -76,7 +76,7 @@ func doRequest(auth *authentication, payload requestPayload) (*http.Response, er
 	if err != nil {
 		return resp, err
 	}
-	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+	if resp.StatusCode < 200 || resp.StatusCode > 300 {
 		resp, err = processSalesforceError(*resp, auth, payload)
 	}
 

--- a/salesforce_test.go
+++ b/salesforce_test.go
@@ -38,8 +38,13 @@ func setupTestServer(body any, status int) (*httptest.Server, authentication) {
 func Test_doRequest(t *testing.T) {
 	server, sfAuth := setupTestServer("", http.StatusOK)
 	defer server.Close()
+
 	badServer, badSfAuth := setupTestServer("", http.StatusBadRequest)
 	defer badServer.Close()
+
+	recordArrayResp := [2]string{"testRecord1", "testRecord2"}
+	serverWith300Resp, authWith300Resp := setupTestServer(recordArrayResp, http.StatusMultipleChoices)
+	defer serverWith300Resp.Close()
 
 	type args struct {
 		auth    *authentication
@@ -78,6 +83,20 @@ func Test_doRequest(t *testing.T) {
 			},
 			want:    http.StatusBadRequest,
 			wantErr: true,
+		},
+		{
+			name: "handle_multiple_records_with_same_externalId_statusCode_300",
+			args: args{
+				auth: &authWith300Resp,
+				payload: requestPayload{
+					method:  http.MethodGet,
+					uri:     "/sobjects/Contact/ContactExternalId__c/Avng1",
+					content: jsonType,
+					body:    "",
+				},
+			},
+			want:    http.StatusMultipleChoices,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## What's the problem?

Go-salesforce does not currently handle the edge case where multiple records have the same External Id. While usually an External Id field is marked as unique, it doesn't have to be. So if 2 or more records have the External Id of `Avng1`, and you run the following code, then you get a runtime error.

```go
resp, err := sf.DoRequest(http.MethodGet, "/sobjects/Contact/ContactExternalId__c/Avng1", nil)
```

`json: cannot unmarshal string into Go value of type salesforce.SalesforceErrorMessage`

This is because Salesforce is returning the status of `300: MultipleChoices`. The response body looks something like this:

`["/services/data/v60.0/sobjects/Contact/003Dn00000srto9IAA","/services/data/v60.0/sobjects/Contact/003Dn00000srtA8IAI"]`

Go-salesforce is trying to marshal this into the `SalesforceErrorMessage` type, hence the runtime error.

## The Solution

Update Go-salesforce to treat the 300 status code as a successful response. This is far more useful anyways, as throwing an error might give the impression that a matching record wasn't found. Now users can successfully retrieve records using External Ids, even when the External Id isn't unique.