### PR TITLE
[feature] Query Explain Plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,21 @@ if err != nil {
 }
 ```
 
+### QueryExplain
+
+`func (sf *Salesforce) QueryExplain(query string) (*ExplainResponse, error)`
+
+Performs a SOQL query explain given a query string and return the performance feedback analysis report
+
+- `query`: a SOQL query
+
+```go
+explain, err := sf.QueryExplain("SELECT Id, LastName FROM Contact WHERE LastName = 'Lee'")
+if err != nil {
+    panic(err)
+}
+
+
 ### Handling Relationship Queries
 
 When querying Salesforce objects, it's common to access fields that are related through parent-child or lookup relationships. For instance, querying `Account.Name` with related `Contact` might look like this:

--- a/explain.go
+++ b/explain.go
@@ -1,0 +1,47 @@
+package salesforce
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+)
+
+type note struct {
+	Description   string   `json:"description"`
+	Fields        []string `json:"fields"`
+	TableEnumOrId string   `json:"tableEnumOrId"`
+}
+
+type ExplainPlain struct {
+	Cardinality          int64    `json:"cardinality"`
+	Fields               []string `json:"fields"`
+	LeadingOperationType string   `json:"leadingOperationType"`
+	Notes                []note   `json:"notes"`
+	RelativeCost         float64  `json:"relativeCost"`
+	SObjectCardinality   int64
+	SObjectType          string `json:"sobjectType"`
+}
+
+func performExplain(auth *authentication, query string) ([]ExplainPlain, error) {
+	query = url.QueryEscape(query)
+
+	explainURL := "/query/?explain=" + query
+	resp, err := doRequest(auth, requestPayload{
+		method:  http.MethodGet,
+		uri:     explainURL,
+		content: jsonType,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	dec := json.NewDecoder(resp.Body)
+	var explainResp = struct {
+		Plans []ExplainPlain `json:"plans"`
+	}{}
+	if queryResponseError := dec.Decode(&explainResp); queryResponseError != nil {
+		return nil, queryResponseError
+	}
+
+	return explainResp.Plans, nil
+}

--- a/salesforce.go
+++ b/salesforce.go
@@ -297,6 +297,20 @@ func (sf *Salesforce) QueryStruct(soqlStruct any, sObject any) error {
 	return nil
 }
 
+func (sf *Salesforce) QueryExplain(query string) ([]ExplainPlain, error) {
+	authErr := validateAuth(*sf)
+	if authErr != nil {
+		return nil, authErr
+	}
+
+	explainResp, queryErr := performExplain(sf.auth, query)
+	if queryErr != nil {
+		return nil, queryErr
+	}
+
+	return explainResp, nil
+}
+
 func (sf *Salesforce) InsertOne(sObjectName string, record any) (SalesforceResult, error) {
 	validationErr := validateSingles(*sf, record)
 	if validationErr != nil {


### PR DESCRIPTION
A feature to return plans of a Query, without executing it.

Analyzes the performance of a specified SOQL query, report, or list view.

[sf query explain](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_query_performance_feedback.htm)