### PR TITLE
basic config for codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80
+    patch: false


### PR DESCRIPTION
- remove patch notifications - was showing failing statuses when not really needed
- target 80% code coverage (this is a base requirement for awesome-go)