### PR TITLE
Add support for custom headers in `DoRequest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1211,26 +1211,42 @@ for _, id := range jobIds {
 
 ### DoRequest
 
-`func (sf *Salesforce) DoRequest(method string, uri string, body []byte) (*http.Response, error)`
+`func (sf *Salesforce) DoRequest(method string, uri string, body []byte, opts ...RequestOption) (*http.Response, error)`
 
 Make a http call to Salesforce, returning a response to be parsed by the client
 
 - `method`: request method ("GET", "POST", "PUT", "PATCH", "DELETE")
 - `uri`: uniform resource identifier (include everything after `/services/data/apiVersion`)
 - `body`: json encoded body to be included in request
+- `opts`: optional request options (currently supports custom headers via `WithHeader`)
 
-Example to call the `/limits` endpoint
+#### WithHeader
+
+`func WithHeader(key, value string) RequestOption`
+
+Creates a request option that sets a custom header on the HTTP request
+
+- `key`: the header name
+- `value`: the header value
 
 ```go
-resp, err := sf.DoRequest(http.MethodGet, "/limits", nil)
+// Use If-Modified-Since for efficient caching
+resp, err := sf.DoRequest("GET", "/sobjects/Account/describe", nil,
+    salesforce.WithHeader("If-Modified-Since", "Wed, 21 Oct 2015 07:28:00 GMT"))
 if err != nil {
     panic(err)
 }
-respBody, err := io.ReadAll(resp.Body)
-if err != nil {
-    panic(err)
+
+if resp.StatusCode == 304 {
+    fmt.Println("Data not modified, using cached version")
 }
-fmt.Println(string(respBody))
+```
+
+```go
+// Multiple custom headers
+resp, err := sf.DoRequest("GET", "/sobjects", nil,
+    salesforce.WithHeader("If-Modified-Since", "Wed, 21 Oct 2015 07:28:00 GMT"),
+    salesforce.WithHeader("Accept-Language", "en-US"))
 ```
 
 ## Contributing

--- a/salesforce.go
+++ b/salesforce.go
@@ -195,7 +195,7 @@ func Init(creds Creds) (*Salesforce, error) {
 	return &Salesforce{auth: auth, Config: config}, nil
 }
 
-func (sf *Salesforce) DoRequest(method string, uri string, body []byte) (*http.Response, error) {
+func (sf *Salesforce) DoRequest(method string, uri string, body []byte, opts ...RequestOption) (*http.Response, error) {
 	authErr := validateAuth(*sf)
 	if authErr != nil {
 		return nil, authErr
@@ -207,6 +207,7 @@ func (sf *Salesforce) DoRequest(method string, uri string, body []byte) (*http.R
 		content:  jsonType,
 		body:     string(body),
 		compress: sf.Config.CompressionHeaders,
+		options:  opts,
 	})
 	if err != nil {
 		return nil, err

--- a/salesforce_test.go
+++ b/salesforce_test.go
@@ -588,9 +588,10 @@ func TestSalesforce_DoRequest(t *testing.T) {
 		auth *authentication
 	}
 	type args struct {
-		method string
-		uri    string
-		body   []byte
+		method  string
+		uri     string
+		body    []byte
+		options []RequestOption
 	}
 	tests := []struct {
 		name    string
@@ -616,6 +617,25 @@ func TestSalesforce_DoRequest(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "successful_request_with_header",
+			fields: fields{
+				auth: &sfAuth,
+			},
+			args: args{
+				method: http.MethodGet,
+				uri:    "/request",
+				body:   []byte("example"),
+				options: []RequestOption{
+					WithHeader("If-Modified-Since", "Wed, 21 Oct 2015 07:28:00 GMT"),
+				},
+			},
+			want: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("\"response_body\"")),
+			},
+			wantErr: false,
+		},
+		{
 			name: "validation_fail_auth",
 			fields: fields{
 				auth: nil,
@@ -631,7 +651,7 @@ func TestSalesforce_DoRequest(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sf := buildSalesforceStruct(tt.fields.auth)
-			got, err := sf.DoRequest(tt.args.method, tt.args.uri, tt.args.body)
+			got, err := sf.DoRequest(tt.args.method, tt.args.uri, tt.args.body, tt.args.options...)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Salesforce.DoRequest() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
This pull request introduces functional options for configuring HTTP requests in the Salesforce client library. The most notable change is the addition of support for custom headers via the `RequestOption` type.

- [`requests.go`](diffhunk://#diff-b9de0ffbcda0b4e637c5045a32d88e2f1cb3979569132333acfcdae758a81f6cR13-R30): Introduced a new `RequestOption` type and the `WithHeader` function to set custom headers on HTTP requests. Updated the `doRequest` function to apply these options. [[1]](diffhunk://#diff-b9de0ffbcda0b4e637c5045a32d88e2f1cb3979569132333acfcdae758a81f6cR13-R30) [[2]](diffhunk://#diff-b9de0ffbcda0b4e637c5045a32d88e2f1cb3979569132333acfcdae758a81f6cR65-R69)

- [`salesforce.go`](diffhunk://#diff-538c945d4eb7aaec117332f2137c5ae261f5e2e9988b72335f8183a60259d556L198-R198): Modified the `DoRequest` method to accept variadic `RequestOption` arguments and pass them to the `requestPayload`. [[1]](diffhunk://#diff-538c945d4eb7aaec117332f2137c5ae261f5e2e9988b72335f8183a60259d556L198-R198) [[2]](diffhunk://#diff-538c945d4eb7aaec117332f2137c5ae261f5e2e9988b72335f8183a60259d556R210)

- [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1214-R1249): Updated the `DoRequest` method documentation to include the new `opts` parameter and added examples demonstrating its usage.

- [`salesforce_test.go`](diffhunk://#diff-c6c9d1342d6f1fb5472ac109754a592da86c8bea8e9c59602a55e9f5b8455207R594): Added test cases for `DoRequest` to verify the functionality of custom headers using `RequestOption`. [[1]](diffhunk://#diff-c6c9d1342d6f1fb5472ac109754a592da86c8bea8e9c59602a55e9f5b8455207R594) [[2]](diffhunk://#diff-c6c9d1342d6f1fb5472ac109754a592da86c8bea8e9c59602a55e9f5b8455207R619-R637) [[3]](diffhunk://#diff-c6c9d1342d6f1fb5472ac109754a592da86c8bea8e9c59602a55e9f5b8455207L634-R654)