### PR TITLE
feat--- make bulk job polling timeout configurable

### DIFF
--- a/HTTP_CLIENT_CONFIG.md
+++ b/HTTP_CLIENT_CONFIG.md
@@ -57,6 +57,7 @@ func main() {
 | `WithCompressionHeaders(enabled bool)` | Enable/disable compression | false |
 | `WithBatchSizeMax(size int)` | Set max batch size for collections | 200 |
 | `WithBulkBatchSizeMax(size int)` | Set max batch size for bulk operations | 10000 |
+| `WithBulkPollTimeout(timeout time.Duration)` | Set timeout for polling bulk results | 1m |
 
 ## Default HTTP Client Configuration
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Optional configuration:
 - `func WithAPIVersion(version string) Option` - set API version manually instead of using default
 - `func WithBatchSizeMax(size int)` - for collections API
 - `func WithBulkBatchSizeMax(size int) Option` - for Bulk API
+- `func WithBulkPollTimeout(timeout time.Duration) Option` - set max wait when polling bulk results with `waitForResults=true`
 - `func WithRoundTripper(rt http.RoundTripper) Option` - for http requests
 - `func WithHTTPTimeout(timeout time.Duration) Option` - set custom timeout
 - `func WithValidateAuthentication(validate bool) Option` - optionally skip validation during certain auth flows

--- a/bulk.go
+++ b/bulk.go
@@ -202,7 +202,7 @@ func waitForJobResultsAsync(
 	err := pollUntilContextTimeout(
 		context.Background(),
 		interval,
-		time.Minute,
+		sf.config.bulkPollTimeout,
 		func(context.Context) (bool, error) {
 			bulkJob, reqErr := getJobResults(sf, jobType, bulkJobId)
 			if reqErr != nil {
@@ -223,7 +223,7 @@ func waitForJobResults(
 	err := pollUntilContextTimeout(
 		context.Background(),
 		interval,
-		time.Minute,
+		sf.config.bulkPollTimeout,
 		func(context.Context) (bool, error) {
 			bulkJob, reqErr := getJobResults(sf, jobType, bulkJobId)
 			if reqErr != nil {

--- a/bulk_test.go
+++ b/bulk_test.go
@@ -1,8 +1,10 @@
 package salesforce
 
 import (
+	"context"
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -826,6 +828,54 @@ func Test_waitForJobResults(t *testing.T) {
 				t.Errorf("waitForQueryResults() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func Test_waitForJobResults_UsesConfiguredTimeout(t *testing.T) {
+	jobResults := BulkJobResults{
+		Id:    "1234",
+		State: jobStateOpen,
+	}
+	server, sfAuth := setupTestServer(jobResults, http.StatusOK)
+	defer server.Close()
+
+	sf := buildSalesforceStruct(&sfAuth)
+	sf.config.bulkPollTimeout = 2 * time.Millisecond
+
+	err := waitForJobResults(
+		sf,
+		"1234",
+		ingestJobType,
+		time.Millisecond,
+	)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("waitForJobResults() error = %v, want %v", err, context.DeadlineExceeded)
+	}
+}
+
+func Test_waitForJobResultsAsync_UsesConfiguredTimeout(t *testing.T) {
+	jobResults := BulkJobResults{
+		Id:    "1234",
+		State: jobStateOpen,
+	}
+	server, sfAuth := setupTestServer(jobResults, http.StatusOK)
+	defer server.Close()
+
+	sf := buildSalesforceStruct(&sfAuth)
+	sf.config.bulkPollTimeout = 2 * time.Millisecond
+	c := make(chan error)
+
+	go waitForJobResultsAsync(
+		sf,
+		"1234",
+		ingestJobType,
+		time.Millisecond,
+		c,
+	)
+	err := <-c
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("waitForJobResultsAsync() error = %v, want %v", err, context.DeadlineExceeded)
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -14,6 +14,7 @@ type configuration struct {
 	apiVersion                   string
 	batchSizeMax                 int
 	bulkBatchSizeMax             int
+	bulkPollTimeout              time.Duration // timeout for waiting on bulk job completion
 	httpClient                   *http.Client      // HTTP client (created internally)
 	roundTripper                 http.RoundTripper // Custom round tripper
 	shouldValidateAuthentication bool              // Validate session on client creation
@@ -26,6 +27,7 @@ func (c *configuration) setDefaults() {
 	c.apiVersion = apiVersion
 	c.batchSizeMax = batchSizeMax
 	c.bulkBatchSizeMax = bulkBatchSizeMax
+	c.bulkPollTimeout = bulkPollTimeout
 	c.httpTimeout = httpDefaultTimeout
 }
 
@@ -104,6 +106,17 @@ func WithBulkBatchSizeMax(size int) Option {
 			return errors.New("bulk batch size max must be between 1 and 10000")
 		}
 		c.bulkBatchSizeMax = size
+		return nil
+	}
+}
+
+// WithBulkPollTimeout sets the timeout for polling bulk job results.
+func WithBulkPollTimeout(timeout time.Duration) Option {
+	return func(c *configuration) error {
+		if timeout <= 0 {
+			return errors.New("bulk poll timeout must be greater than 0")
+		}
+		c.bulkPollTimeout = timeout
 		return nil
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -2,6 +2,7 @@ package salesforce
 
 import (
 	"testing"
+	"time"
 )
 
 func TestWithCompressionHeaders(t *testing.T) {
@@ -181,6 +182,56 @@ func TestWithBulkBatchSizeMax(t *testing.T) {
 	}
 }
 
+func TestWithBulkPollTimeout(t *testing.T) {
+	tests := []struct {
+		name      string
+		timeout   time.Duration
+		wantErr   bool
+		wantValue time.Duration
+	}{
+		{
+			name:      "valid_timeout",
+			timeout:   10 * time.Minute,
+			wantErr:   false,
+			wantValue: 10 * time.Minute,
+		},
+		{
+			name:      "zero_timeout",
+			timeout:   0,
+			wantErr:   true,
+			wantValue: 0,
+		},
+		{
+			name:      "negative_timeout",
+			timeout:   -1 * time.Second,
+			wantErr:   true,
+			wantValue: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := configuration{}
+			config.setDefaults()
+
+			option := WithBulkPollTimeout(tt.timeout)
+			err := option(&config)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("WithBulkPollTimeout() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr && config.bulkPollTimeout != tt.wantValue {
+				t.Errorf(
+					"WithBulkPollTimeout() = %v, want %v",
+					config.bulkPollTimeout,
+					tt.wantValue,
+				)
+			}
+		})
+	}
+}
+
 func TestConfigurationDefaults(t *testing.T) {
 	config := configuration{}
 	config.setDefaults()
@@ -209,6 +260,14 @@ func TestConfigurationDefaults(t *testing.T) {
 			"Expected bulkBatchSizeMax default to be %v, got %v",
 			bulkBatchSizeMax,
 			config.bulkBatchSizeMax,
+		)
+	}
+
+	if config.bulkPollTimeout != bulkPollTimeout {
+		t.Errorf(
+			"Expected bulkPollTimeout default to be %v, got %v",
+			bulkPollTimeout,
+			config.bulkPollTimeout,
 		)
 	}
 }

--- a/examples/functional-config/main.go
+++ b/examples/functional-config/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/k-capehart/go-salesforce/v3"
 )
@@ -37,6 +38,7 @@ func main() {
 		salesforce.WithAPIVersion("v58.0"),
 		salesforce.WithBatchSizeMax(150),
 		salesforce.WithBulkBatchSizeMax(8000),
+		salesforce.WithBulkPollTimeout(10*time.Minute),
 		salesforce.WithCompressionHeaders(true),
 	)
 	if err != nil {

--- a/salesforce.go
+++ b/salesforce.go
@@ -43,6 +43,7 @@ const (
 	csvType                       = "text/csv"
 	batchSizeMax                  = 200
 	bulkBatchSizeMax              = 10000
+	bulkPollTimeout               = time.Duration(1 * time.Minute)
 	invalidSessionIdError         = "INVALID_SESSION_ID"
 	httpDefaultMaxIdleConnections = 10
 	httpDefaultIdleConnTimeout    = time.Duration(30 * time.Second)


### PR DESCRIPTION
## Summary
Makes Bulk API polling timeout configurable for `waitForResults=true` operations, while keeping the default behavior unchanged.

## Changes
- Added new functional option:
  - `WithBulkPollTimeout(timeout time.Duration) Option`
- Added validation:
  - returns error when `timeout <= 0`
- Added configuration default:
  - `bulkPollTimeout = 1 * time.Minute` (backward compatible)
- Updated bulk polling internals to use configured timeout instead of hardcoded `time.Minute`:
  - `waitForJobResults`
  - `waitForJobResultsAsync`
- Added tests:
  - `TestWithBulkPollTimeout`
  - `Test_waitForJobResults_UsesConfiguredTimeout`
  - `Test_waitForJobResultsAsync_UsesConfiguredTimeout`
- Updated documentation/examples:
  - `README.md`
  - `HTTP_CLIENT_CONFIG.md`
  - `examples/functional-config/main.go`

## Verification
- `go test ./...`
- `go test -run 'TestWithBulkPollTimeout|Test_waitForJobResults_UsesConfiguredTimeout|Test_waitForJobResultsAsync_UsesConfiguredTimeout' ./...`

Note: I do not have Salesforce credentials available in this environment, so live org validation was not run here.

Closes #139

@k-capehart could you review this when you have a chance?
