### PR TITLE
feat: make authentication flows also use the custom HTTP client configuration

### DIFF
--- a/HTTP_CLIENT_CONFIG.md
+++ b/HTTP_CLIENT_CONFIG.md
@@ -41,6 +41,38 @@ func main() {
 }
 ```
 
+### Custom Round Tripper with Proxy
+
+```go
+func main() {
+    proxyURL, _ := url.Parse("http://my-proxy:8080")
+    
+    // Create a custom round tripper that uses a proxy
+    customRoundTripper := &http.Transport{
+        Proxy: http.ProxyURL(proxyURL),
+        TLSClientConfig: &tls.Config{
+            MinVersion: tls.VersionTLS12,
+        },
+        MaxIdleConns:       10,
+        IdleConnTimeout:    30 * time.Second,
+        DisableCompression: false,
+    }
+
+    creds := salesforce.Creds{
+        // ... your credentials
+    }
+
+    // Initialize with custom round tripper
+    sf, err := salesforce.Init(creds, 
+        salesforce.WithRoundTripper(customRoundTripper),
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+}
+```
+
+
 ## Configuration Options
 
 ### HTTP Client Options

--- a/HTTP_CLIENT_CONFIG.md
+++ b/HTTP_CLIENT_CONFIG.md
@@ -14,7 +14,9 @@ The Salesforce Go client now supports custom HTTP transport layer configuration,
 
 ```go
 func main() {
-    // Create a custom round tripper for fine-grained HTTP control
+    // Create a custom round tripper for fine-grained HTTP control\
+    // options include proxy, tls, etc
+    proxyURL, _ := url.Parse("http://my-proxy:8080")
     customRoundTripper := &http.Transport{
         TLSClientConfig: &tls.Config{
             MinVersion: tls.VersionTLS12,
@@ -24,6 +26,7 @@ func main() {
         DisableCompression:  false,
         DisableKeepAlives:   false,
         MaxIdleConnsPerHost: 5,
+        Proxy: http.ProxyURL(proxyURL), // optional
     }
 
     creds := salesforce.Creds{
@@ -40,38 +43,6 @@ func main() {
     }
 }
 ```
-
-### Custom Round Tripper with Proxy
-
-```go
-func main() {
-    proxyURL, _ := url.Parse("http://my-proxy:8080")
-    
-    // Create a custom round tripper that uses a proxy
-    customRoundTripper := &http.Transport{
-        Proxy: http.ProxyURL(proxyURL),
-        TLSClientConfig: &tls.Config{
-            MinVersion: tls.VersionTLS12,
-        },
-        MaxIdleConns:       10,
-        IdleConnTimeout:    30 * time.Second,
-        DisableCompression: false,
-    }
-
-    creds := salesforce.Creds{
-        // ... your credentials
-    }
-
-    // Initialize with custom round tripper
-    sf, err := salesforce.Init(creds, 
-        salesforce.WithRoundTripper(customRoundTripper),
-    )
-    if err != nil {
-        log.Fatal(err)
-    }
-}
-```
-
 
 ## Configuration Options
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Optional configuration:
 - `func WithAPIVersion(version string) Option` - set API version manually instead of using default
 - `func WithBatchSizeMax(size int)` - for collections API
 - `func WithBulkBatchSizeMax(size int) Option` - for Bulk API
-- `func WithRoundTripper(rt http.RoundTripper) Option` - for http requests
+- `func WithRoundTripper(rt http.RoundTripper) Option` - for http requests (e.g., custom transport with proxy)
 - `func WithHTTPTimeout(timeout time.Duration) Option` - set custom timeout
 - `func WithValidateAuthentication(validate bool) Option` - optionally skip validation during certain auth flows
 

--- a/README.md
+++ b/README.md
@@ -202,10 +202,9 @@ Optional configuration:
 - `func WithAPIVersion(version string) Option` - set API version manually instead of using default
 - `func WithBatchSizeMax(size int)` - for collections API
 - `func WithBulkBatchSizeMax(size int) Option` - for Bulk API
-- `func WithRoundTripper(rt http.RoundTripper) Option` - for http requests (e.g., custom transport with proxy)
 - `func WithBulkPollTimeout(timeout time.Duration) Option` - set max wait when polling bulk results with `waitForResults=true`
 - `func WithRoundTripper(rt http.RoundTripper) Option` - for http requests
-- `func WithHTTPTimeout(timeout time.Duration) Option` - set custom timeout
+- `func WithHTTPTimeout(timeout time.Duration) Option` - set custom timeout, e.g. for proxy
 - `func WithValidateAuthentication(validate bool) Option` - optionally skip validation during certain auth flows
 
 Get configuration:

--- a/auth.go
+++ b/auth.go
@@ -95,19 +95,21 @@ func (conf *configuration) validateAuthentication(auth authentication) error {
 	return nil
 }
 
-func refreshSession(auth *authentication) error {
+func refreshSession(config *configuration, auth *authentication) error {
 	var refreshedAuth *authentication
 	var err error
 
 	switch grantType := auth.grantType; grantType {
 	case grantTypeClientCredentials:
 		refreshedAuth, err = clientCredentialsFlow(
+			config,
 			auth.InstanceUrl,
 			auth.creds.ConsumerKey,
 			auth.creds.ConsumerSecret,
 		)
 	case grantTypeUsernamePassword:
 		refreshedAuth, err = usernamePasswordFlow(
+			config,
 			auth.InstanceUrl,
 			auth.creds.Username,
 			auth.creds.Password,
@@ -117,6 +119,7 @@ func refreshSession(auth *authentication) error {
 		)
 	case grantTypeJWT:
 		refreshedAuth, err = jwtFlow(
+			config,
 			auth.InstanceUrl,
 			auth.creds.Username,
 			auth.creds.ConsumerKey,
@@ -143,8 +146,14 @@ func refreshSession(auth *authentication) error {
 	return nil
 }
 
-func doAuth(url string, body *strings.Reader) (*authentication, error) {
-	resp, err := http.Post(url, "application/x-www-form-urlencoded", body)
+func doAuth(config *configuration, url string, body *strings.Reader) (*authentication, error) {
+	req, err := http.NewRequest(http.MethodPost, url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := config.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -170,6 +179,7 @@ func doAuth(url string, body *strings.Reader) (*authentication, error) {
 }
 
 func usernamePasswordFlow(
+	config *configuration,
 	domain string,
 	username string,
 	password string,
@@ -186,7 +196,7 @@ func usernamePasswordFlow(
 	}
 	endpoint := "/services/oauth2/token"
 	body := strings.NewReader(payload.Encode())
-	auth, err := doAuth(domain+endpoint, body)
+	auth, err := doAuth(config, domain+endpoint, body)
 	if err != nil {
 		return nil, err
 	}
@@ -195,6 +205,7 @@ func usernamePasswordFlow(
 }
 
 func clientCredentialsFlow(
+	config *configuration,
 	domain string,
 	consumerKey string,
 	consumerSecret string,
@@ -206,7 +217,7 @@ func clientCredentialsFlow(
 	}
 	endpoint := "/services/oauth2/token"
 	body := strings.NewReader(payload.Encode())
-	auth, err := doAuth(domain+endpoint, body)
+	auth, err := doAuth(config, domain+endpoint, body)
 	if err != nil {
 		return nil, err
 	}
@@ -229,6 +240,7 @@ func (conf *configuration) getAccessTokenAuthentication(
 }
 
 func jwtFlow(
+	config *configuration,
 	domain string,
 	username string,
 	consumerKey string,
@@ -263,7 +275,7 @@ func jwtFlow(
 	}
 	endpoint := "/services/oauth2/token"
 	body := strings.NewReader(payload.Encode())
-	auth, err := doAuth(domain+endpoint, body)
+	auth, err := doAuth(config, domain+endpoint, body)
 	if err != nil {
 		return nil, err
 	}

--- a/auth.go
+++ b/auth.go
@@ -173,7 +173,11 @@ func doAuth(config *configuration, url string, body *strings.Reader) (*authentic
 	}
 
 	defer func() {
-		err = resp.Body.Close()
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			if err == nil {
+				err = closeErr
+			}
+		}
 	}()
 	return auth, err
 }

--- a/auth_test.go
+++ b/auth_test.go
@@ -101,7 +101,9 @@ func Test_usernamePasswordFlow(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			config := getDefaultConfig(t)
 			got, err := usernamePasswordFlow(
+				config,
 				tt.args.domain,
 				tt.args.username,
 				tt.args.password,
@@ -169,7 +171,9 @@ func Test_clientCredentialsFlow(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			config := getDefaultConfig(t)
 			got, err := clientCredentialsFlow(
+				config,
 				tt.args.domain,
 				tt.args.consumerKey,
 				tt.args.consumerSecret,
@@ -345,7 +349,8 @@ func Test_refreshSession(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := refreshSession(tt.args.auth); (err != nil) != tt.wantErr {
+			config := getDefaultConfig(t)
+			if err := refreshSession(config, tt.args.auth); (err != nil) != tt.wantErr {
 				t.Errorf("refreshSession() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -406,7 +411,9 @@ func Test_jwtFlow(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			config := getDefaultConfig(t)
 			got, err := jwtFlow(
+				config,
 				tt.args.domain,
 				tt.args.username,
 				tt.args.consumerKey,

--- a/config_http_test.go
+++ b/config_http_test.go
@@ -1,7 +1,10 @@
 package salesforce
 
 import (
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 )
@@ -145,6 +148,70 @@ func TestConfigurationHTTPClientDefaults(t *testing.T) {
 			)
 		}
 	})
+}
+
+func TestConfigurationWithProxy(t *testing.T) {
+	// 1. Create a dummy target server (we expect the proxy to intercept before this is hit)
+	targetHit := false
+	targetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetHit = true
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("target reached"))
+	}))
+	defer targetServer.Close()
+
+	// 2. Create a proxy server
+	proxyHit := false
+	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxyHit = true
+		// Verify this is a proxy request for the target server
+		if r.URL.Host != targetServer.Listener.Addr().String() {
+			t.Errorf("Proxy received request for unexpected host: %s", r.URL.Host)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("proxy reached"))
+	}))
+	defer proxyServer.Close()
+
+	proxyURL, _ := url.Parse(proxyServer.URL)
+
+	// 3. Configure custom round tripper with proxy
+	customRoundTripper := &http.Transport{
+		Proxy: http.ProxyURL(proxyURL),
+	}
+
+	config := &configuration{}
+	config.setDefaults()
+	err := WithRoundTripper(customRoundTripper)(config)
+	if err != nil {
+		t.Fatalf("Expected no error from WithRoundTripper, got %v", err)
+	}
+	config.configureHttpClient()
+
+	// 4. Make a request to the target server using the configured client
+	req, err := http.NewRequest(http.MethodGet, targetServer.URL, nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	resp, err := config.httpClient.Do(req)
+	if err != nil {
+		t.Fatalf("Expected no error executing request, got %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+
+	// 5. Verify the request went through the proxy and not directly to the target
+	if !proxyHit {
+		t.Errorf("Expected request to go through proxy but it did not")
+	}
+	if targetHit {
+		t.Errorf("Expected request to be intercepted by proxy but target was hit directly")
+	}
+	if string(body) != "proxy reached" {
+		t.Errorf("Expected response from proxy, got %s", string(body))
+	}
 }
 
 func TestSalesforceGetHTTPClient(t *testing.T) {

--- a/config_http_test.go
+++ b/config_http_test.go
@@ -153,24 +153,34 @@ func TestConfigurationHTTPClientDefaults(t *testing.T) {
 func TestConfigurationWithProxy(t *testing.T) {
 	// 1. Create a dummy target server (we expect the proxy to intercept before this is hit)
 	targetHit := false
-	targetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		targetHit = true
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("target reached"))
-	}))
+	targetServer := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			targetHit = true
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte("target reached"))
+			if err != nil {
+				t.Errorf("Failed to write response: %v", err)
+			}
+		}),
+	)
 	defer targetServer.Close()
 
 	// 2. Create a proxy server
 	proxyHit := false
-	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		proxyHit = true
-		// Verify this is a proxy request for the target server
-		if r.URL.Host != targetServer.Listener.Addr().String() {
-			t.Errorf("Proxy received request for unexpected host: %s", r.URL.Host)
-		}
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("proxy reached"))
-	}))
+	proxyServer := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			proxyHit = true
+			// Verify this is a proxy request for the target server
+			if r.URL.Host != targetServer.Listener.Addr().String() {
+				t.Errorf("Proxy received request for unexpected host: %s", r.URL.Host)
+			}
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte("proxy reached"))
+			if err != nil {
+				t.Errorf("Failed to write response: %v", err)
+			}
+		}),
+	)
 	defer proxyServer.Close()
 
 	proxyURL, _ := url.Parse(proxyServer.URL)
@@ -198,7 +208,11 @@ func TestConfigurationWithProxy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected no error executing request, got %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Errorf("Failed to close response body: %v", closeErr)
+		}
+	}()
 
 	body, _ := io.ReadAll(resp.Body)
 

--- a/requests.go
+++ b/requests.go
@@ -137,7 +137,7 @@ func processSalesforceError(
 	for _, sfError := range sfErrors {
 		if sfError.ErrorCode == invalidSessionIdError &&
 			!payload.retry { // only attempt to refresh the session once
-			err = refreshSession(auth)
+			err = refreshSession(config, auth)
 			if err != nil {
 				return &resp, err
 			}

--- a/salesforce.go
+++ b/salesforce.go
@@ -190,6 +190,7 @@ func Init(creds Creds, options ...Option) (*Salesforce, error) {
 	if creds.Domain != "" && creds.ConsumerKey != "" && creds.ConsumerSecret != "" &&
 		creds.Username != "" && creds.Password != "" && creds.SecurityToken != "" {
 		auth, err = usernamePasswordFlow(
+			config,
 			creds.Domain,
 			creds.Username,
 			creds.Password,
@@ -200,6 +201,7 @@ func Init(creds Creds, options ...Option) (*Salesforce, error) {
 		authFlow = AuthFlowUsernamePassword
 	} else if creds.Domain != "" && creds.ConsumerKey != "" && creds.ConsumerSecret != "" {
 		auth, err = clientCredentialsFlow(
+			config,
 			creds.Domain,
 			creds.ConsumerKey,
 			creds.ConsumerSecret,
@@ -214,6 +216,7 @@ func Init(creds Creds, options ...Option) (*Salesforce, error) {
 	} else if creds.Domain != "" && creds.Username != "" &&
 		creds.ConsumerKey != "" && creds.ConsumerRSAPem != "" {
 		auth, err = jwtFlow(
+			config,
 			creds.Domain,
 			creds.Username,
 			creds.ConsumerKey,


### PR DESCRIPTION
# Description
This PR updates the authentication flows in 

auth.go to utilize the custom HTTP client configured during salesforce.Init(), rather than relying on the default http.Post client.

Why is this needed? At my company, we are required to route all external connections through a corporate proxy. Previously, the authentication requests (usernamePasswordFlow, clientCredentialsFlow, jwtFlow , etc.) were hard-coded to use the default http client, which meant they bypassed any custom http.RoundTripper configurations (like proxy settings) passed into salesforce.Init(). This resulted in failed authentication attempts since the initial connection to Salesforce couldn't be established through our proxy.
By injecting the configuration object down into  doAuth and the respective authentication flows, the authentication handshakes now correctly respect the custom http.RoundTripper and timeout configurations defined by the user.

# Changes Made
- auth.go: Updated  doAuth, refreshSession ,  usernamePasswordFlow ,  clientCredentialsFlow , and  jwtFlow to accept the config *configuration parameter. Refactored  doAuth to use http.NewRequest and config.httpClient.Do(req) instead of http.Post.
- salesforce.go : Updated the initialization flow ( Init ) to pass the locally scoped config into the authentication functions.
- requests.go : Updated  processSalesforceError to seamlessly pass the  config object down into  refreshSession .
- auth_test.go : Injected a default configuration object into the test suites to ensure they compile and pass with the updated function signatures.
- config_http_test.go: Added a new integration test ( TestConfigurationWithProxy)  that explicitly tests a custom http.RoundTripper proxy to ensure traffic is intercepted and routed correctly.

Documentation: Updated  README.md and  HTTP_CLIENT_CONFIG.md to explicitly mention proxy support and provide code examples on how to configure a custom proxy.

# Testing
- go test -v ./... passes successfully.
- TestConfigurationWithProxy
 verified locally to ensure the proxy logic is solid.
Let me know if you would like me to adjust the tone or add any other specific details to the description!