### PR TITLE
feat: Support Custom Tags for Mapstructure and CSV Decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ type configuration struct {
     roundTripper                 http.RoundTripper
     shouldValidateAuthentication bool
     httpTimeout                  time.Duration
+    tagName                      string
 }
 
 type Creds struct {
@@ -91,7 +92,7 @@ type BulkJobResults struct {
 
 ### Salesforce tag
 
-- tag struct fields with the `salesforce` tag to decode them into their Salesforce API field names
+- tag struct fields with the configured tag (default `salesforce`) to decode them into their Salesforce API field names
 
 ```go
 type Account struct {
@@ -206,6 +207,7 @@ Optional configuration:
 - `func WithRoundTripper(rt http.RoundTripper) Option` - for http requests
 - `func WithHTTPTimeout(timeout time.Duration) Option` - set custom timeout
 - `func WithValidateAuthentication(validate bool) Option` - optionally skip validation during certain auth flows
+- `func WithTagName(tagName string) Option` - set custom struct tag for mapstructure and csvutil decoders
 
 Get configuration:
 - `func (sf *Salesforce) GetAPIVersion() string`
@@ -759,9 +761,9 @@ Performs a query and return a IteratorJob to decode data
 
 ```go
 type Contact struct {
-    Id        string `json:"Id" csv:"Id"`
-    FirstName string `json:"FirstName" csv:"FirstName"`
-    LastName  string `json:"LastName" csv:"LastName"`
+	Id        string `json:"Id" salesforce:"Id"`
+	FirstName string `json:"FirstName" salesforce:"FirstName"`
+	LastName  string `json:"LastName" salesforce:"LastName"`
 }
 
 it, err := sf.QueryBulkIterator("SELECT Id, FirstName, LastName FROM Contact")
@@ -784,13 +786,13 @@ if err := it.Error(); err != nil {
 
 #### Bulk with nested objects
 
-- Nested objects are supported using the `csv` tag
-- The `csv` tag should be formatted as `csv:"APIFieldName.,inline"`
+- Nested objects are supported using the customized tag (default `salesforce`)
+- The tag should be formatted as `salesforce:"APIFieldName.,inline"`
 
 ```go
 type ContactWithAltOwner struct {
-    Id                 string
-    AlternateOwnerName User `csv:"Alternate_Owner__r.,inline"`
+	Id                 string
+	AlternateOwnerName User `salesforce:"Alternate_Owner__r.,inline"`
 }
 
 it, err = sf.QueryBulkIterator("SELECT Id, Alternate_Owner__r.Name FROM Contact")

--- a/bulk.go
+++ b/bulk.go
@@ -482,7 +482,7 @@ func doBulkJob(
 	waitForResults bool,
 	assignmentRuleId string,
 ) ([]string, error) {
-	recordMap, err := convertToSliceOfMaps(records)
+	recordMap, err := convertToSliceOfMaps(records, sf.config.tagName)
 	if err != nil {
 		return []string{}, err
 	}

--- a/composite.go
+++ b/composite.go
@@ -143,7 +143,7 @@ func doInsertComposite(
 	allOrNone bool,
 	batchSize int,
 ) (SalesforceResults, error) {
-	recordMap, err := convertToSliceOfMaps(records)
+	recordMap, err := convertToSliceOfMaps(records, sf.config.tagName)
 	if err != nil {
 		return SalesforceResults{}, err
 	}
@@ -179,7 +179,7 @@ func doUpdateComposite(
 	allOrNone bool,
 	batchSize int,
 ) (SalesforceResults, error) {
-	recordMap, err := convertToSliceOfMaps(records)
+	recordMap, err := convertToSliceOfMaps(records, sf.config.tagName)
 	if err != nil {
 		return SalesforceResults{}, err
 	}
@@ -219,7 +219,7 @@ func doUpsertComposite(
 	allOrNone bool,
 	batchSize int,
 ) (SalesforceResults, error) {
-	recordMap, err := convertToSliceOfMaps(records)
+	recordMap, err := convertToSliceOfMaps(records, sf.config.tagName)
 	if err != nil {
 		return SalesforceResults{}, err
 	}
@@ -254,7 +254,7 @@ func doDeleteComposite(
 	allOrNone bool,
 	batchSize int,
 ) (SalesforceResults, error) {
-	recordMap, err := convertToSliceOfMaps(records)
+	recordMap, err := convertToSliceOfMaps(records, sf.config.tagName)
 	if err != nil {
 		return SalesforceResults{}, err
 	}

--- a/config.go
+++ b/config.go
@@ -19,6 +19,7 @@ type configuration struct {
 	roundTripper                 http.RoundTripper // Custom round tripper
 	shouldValidateAuthentication bool              // Validate session on client creation
 	httpTimeout                  time.Duration     // HTTP client timeout
+	tagName                      string            // Tag name for mapstructure and csvutil decoders
 }
 
 func (c *configuration) setDefaults() {
@@ -29,6 +30,7 @@ func (c *configuration) setDefaults() {
 	c.bulkBatchSizeMax = bulkBatchSizeMax
 	c.bulkPollTimeout = bulkPollTimeout
 	c.httpTimeout = httpDefaultTimeout
+	c.tagName = "salesforce"
 }
 
 func (c *configuration) configureHttpClient() {
@@ -150,3 +152,15 @@ func WithValidateAuthentication(validate bool) Option {
 		return nil
 	}
 }
+
+// WithTagName sets the default tag name used for decoding responses
+func WithTagName(tagName string) Option {
+	return func(c *configuration) error {
+		if tagName == "" {
+			return errors.New("tag name cannot be empty")
+		}
+		c.tagName = tagName
+		return nil
+	}
+}
+

--- a/config_test.go
+++ b/config_test.go
@@ -270,6 +270,56 @@ func TestConfigurationDefaults(t *testing.T) {
 			config.bulkPollTimeout,
 		)
 	}
+
+	if config.tagName != "salesforce" {
+		t.Errorf("Expected tagName default to be 'salesforce', got %v", config.tagName)
+	}
+}
+
+func TestWithTagName(t *testing.T) {
+	tests := []struct {
+		name      string
+		tagName   string
+		wantErr   bool
+		wantValue string
+	}{
+		{
+			name:      "valid_tag_name",
+			tagName:   "json",
+			wantErr:   false,
+			wantValue: "json",
+		},
+		{
+			name:      "valid_tag_name_csv",
+			tagName:   "csv",
+			wantErr:   false,
+			wantValue: "csv",
+		},
+		{
+			name:      "empty_tag_name",
+			tagName:   "",
+			wantErr:   true,
+			wantValue: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := configuration{}
+			config.setDefaults()
+
+			option := WithTagName(tt.tagName)
+			err := option(&config)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("WithTagName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr && config.tagName != tt.wantValue {
+				t.Errorf("WithTagName() = %v, want %v", config.tagName, tt.wantValue)
+			}
+		})
+	}
 }
 
 func TestWithBulkQueryMaxRecords(t *testing.T) {

--- a/dml.go
+++ b/dml.go
@@ -16,12 +16,12 @@ type sObjectCollection struct {
 	Records   []map[string]any `json:"records"`
 }
 
-func convertToMap(obj any) (map[string]any, error) {
+func convertToMap(obj any, tagName string) (map[string]any, error) {
 	var recordMap map[string]any
 	if _, ok := obj.(map[string]any); ok {
 		recordMap = obj.(map[string]any)
 	} else {
-		err := mapstructureDecode(obj, &recordMap)
+		err := mapstructureDecode(obj, &recordMap, tagName)
 		if err != nil {
 			return nil, errors.New("issue decoding salesforce object, need a key value pair (custom struct or map)")
 		}
@@ -29,12 +29,12 @@ func convertToMap(obj any) (map[string]any, error) {
 	return recordMap, nil
 }
 
-func convertToSliceOfMaps(obj any) ([]map[string]any, error) {
+func convertToSliceOfMaps(obj any, tagName string) ([]map[string]any, error) {
 	var recordMap []map[string]any
 	if _, ok := obj.(map[string]any); ok {
 		recordMap = obj.([]map[string]any)
 	} else {
-		err := mapstructureDecode(obj, &recordMap)
+		err := mapstructureDecode(obj, &recordMap, tagName)
 		if err != nil {
 			return nil, errors.New("issue decoding salesforce object, need a key value pair (custom struct or map)")
 		}
@@ -181,7 +181,7 @@ func convertToString(value any) (string, bool) {
 }
 
 func doInsertOne(sf *Salesforce, sObjectName string, record any) (SalesforceResult, error) {
-	recordMap, err := convertToMap(record)
+	recordMap, err := convertToMap(record, sf.config.tagName)
 	if err != nil {
 		return SalesforceResult{}, err
 	}
@@ -214,7 +214,7 @@ func doInsertOne(sf *Salesforce, sObjectName string, record any) (SalesforceResu
 }
 
 func doUpdateOne(sf *Salesforce, sObjectName string, record any) error {
-	recordMap, err := convertToMap(record)
+	recordMap, err := convertToMap(record, sf.config.tagName)
 	if err != nil {
 		return err
 	}
@@ -252,7 +252,7 @@ func doUpsertOne(
 	fieldName string,
 	record any,
 ) (SalesforceResult, error) {
-	recordMap, err := convertToMap(record)
+	recordMap, err := convertToMap(record, sf.config.tagName)
 	if err != nil {
 		return SalesforceResult{}, err
 	}
@@ -303,7 +303,7 @@ func doUpsertOne(
 }
 
 func doDeleteOne(sf *Salesforce, sObjectName string, record any) error {
-	recordMap, err := convertToMap(record)
+	recordMap, err := convertToMap(record, sf.config.tagName)
 	if err != nil {
 		return err
 	}
@@ -332,7 +332,7 @@ func doInsertCollection(
 	records any,
 	batchSize int,
 ) (SalesforceResults, error) {
-	recordMap, err := convertToSliceOfMaps(records)
+	recordMap, err := convertToSliceOfMaps(records, sf.config.tagName)
 	if err != nil {
 		return SalesforceResults{}, err
 	}
@@ -356,7 +356,7 @@ func doUpdateCollection(
 	records any,
 	batchSize int,
 ) (SalesforceResults, error) {
-	recordMap, err := convertToSliceOfMaps(records)
+	recordMap, err := convertToSliceOfMaps(records, sf.config.tagName)
 	if err != nil {
 		return SalesforceResults{}, err
 	}
@@ -384,7 +384,7 @@ func doUpsertCollection(
 	records any,
 	batchSize int,
 ) (SalesforceResults, error) {
-	recordMap, err := convertToSliceOfMaps(records)
+	recordMap, err := convertToSliceOfMaps(records, sf.config.tagName)
 	if err != nil {
 		return SalesforceResults{}, err
 	}
@@ -402,7 +402,7 @@ func doDeleteCollection(
 	records any,
 	batchSize int,
 ) (SalesforceResults, error) {
-	recordMap, err := convertToSliceOfMaps(records)
+	recordMap, err := convertToSliceOfMaps(records, sf.config.tagName)
 	if err != nil {
 		return SalesforceResults{}, err
 	}
@@ -463,13 +463,16 @@ func doDeleteCollection(
 	return SalesforceResults{Results: results}, nil
 }
 
-func mapstructureDecode(input any, output any) error {
+func mapstructureDecode(input any, output any, tagName string) error {
+	if tagName == "" {
+		tagName = "salesforce"
+	}
 	config := &mapstructure.DecoderConfig{
 		Metadata: nil,
 		Result:   output,
 		// mapstructure is included here to maintain strict backwards compatibility, even though there was no
 		// documentation that this tag was supported. It should be removed in the next major version.
-		TagName: "salesforce,mapstructure",
+		TagName: tagName + ",mapstructure",
 	}
 
 	decoder, err := mapstructure.NewDecoder(config)

--- a/dml.go
+++ b/dml.go
@@ -464,9 +464,6 @@ func doDeleteCollection(
 }
 
 func mapstructureDecode(input any, output any, tagName string) error {
-	if tagName == "" {
-		tagName = "salesforce"
-	}
 	config := &mapstructure.DecoderConfig{
 		Metadata: nil,
 		Result:   output,

--- a/dml.go
+++ b/dml.go
@@ -478,7 +478,6 @@ func mapstructureDecode(input any, output any, tagName string) error {
 		// mapstructure is included here to maintain strict backwards compatibility, even though there was no
 		// documentation that this tag was supported. It should be removed in the next major version.
 		TagName: tagName + ",mapstructure",
-		TagName: "salesforce,mapstructure",
 		// https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_valid_date_formats.htm
 		DecodeHook: StringToTimeHookFunc("2006-01-02T15:04:05.000-0700"),
 	}

--- a/dml_test.go
+++ b/dml_test.go
@@ -46,7 +46,7 @@ func Test_convertToMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := convertToMap(tt.args.obj)
+			got, err := convertToMap(tt.args.obj, "salesforce")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("convertToMap() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -105,7 +105,7 @@ func Test_convertToSliceOfMaps(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := convertToSliceOfMaps(tt.args.obj)
+			got, err := convertToSliceOfMaps(tt.args.obj, "salesforce")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("convertToSliceOfMaps() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/dml_test.go
+++ b/dml_test.go
@@ -1018,7 +1018,7 @@ func Test_mapstructureDecode_StringToTime(t *testing.T) {
 	}
 
 	var output TestStruct
-	err := mapstructureDecode(input, &output)
+	err := mapstructureDecode(input, &output, "salesforce")
 	if err != nil {
 		t.Fatalf("mapstructureDecode failed: %v", err)
 	}
@@ -1085,4 +1085,162 @@ func Test_convertToString(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_mapstructureDecode_CustomTag(t *testing.T) {
+	t.Run("json_tag", func(t *testing.T) {
+		type TestStruct struct {
+			Field1 string `json:"field1"`
+			Field2 int    `json:"field2"`
+		}
+
+		input := map[string]any{
+			"field1": "test value",
+			"field2": 42,
+		}
+
+		var output TestStruct
+		err := mapstructureDecode(input, &output, "json")
+		if err != nil {
+			t.Errorf("mapstructureDecode() error = %v", err)
+			return
+		}
+
+		if output.Field1 != "test value" {
+			t.Errorf("Field1 = %v, want 'test value'", output.Field1)
+		}
+		if output.Field2 != 42 {
+			t.Errorf("Field2 = %v, want 42", output.Field2)
+		}
+	})
+
+	t.Run("csv_tag", func(t *testing.T) {
+		type TestStruct struct {
+			Field1 string `csv:"csvField1"`
+			Field2 int    `csv:"csvField2"`
+		}
+
+		input := map[string]any{
+			"csvField1": "csv test",
+			"csvField2": 100,
+		}
+
+		var output TestStruct
+		err := mapstructureDecode(input, &output, "csv")
+		if err != nil {
+			t.Errorf("mapstructureDecode() error = %v", err)
+			return
+		}
+
+		if output.Field1 != "csv test" {
+			t.Errorf("Field1 = %v, want 'csv test'", output.Field1)
+		}
+		if output.Field2 != 100 {
+			t.Errorf("Field2 = %v, want 100", output.Field2)
+		}
+	})
+
+	t.Run("salesforce_tag", func(t *testing.T) {
+		type TestStruct struct {
+			Field1 string `salesforce:"Name"`
+			Field2 int    `salesforce:"Active"`
+		}
+
+		input := map[string]any{
+			"Name":   "Account Name",
+			"Active": 1,
+		}
+
+		var output TestStruct
+		err := mapstructureDecode(input, &output, "salesforce")
+		if err != nil {
+			t.Errorf("mapstructureDecode() error = %v", err)
+			return
+		}
+
+		if output.Field1 != "Account Name" {
+			t.Errorf("Field1 = %v, want 'Account Name'", output.Field1)
+		}
+		if output.Field2 != 1 {
+			t.Errorf("Field2 = %v, want 1", output.Field2)
+		}
+	})
+
+	t.Run("mapstructure_tag_backward_compatibility", func(t *testing.T) {
+		type TestStruct struct {
+			Field1 string `mapstructure:"mapField1"`
+			Field2 int    `mapstructure:"mapField2"`
+		}
+
+		input := map[string]any{
+			"mapField1": "mapstructure value",
+			"mapField2": 999,
+		}
+
+		var output TestStruct
+		err := mapstructureDecode(input, &output, "salesforce")
+		if err != nil {
+			t.Errorf("mapstructureDecode() error = %v", err)
+			return
+		}
+
+		if output.Field1 != "mapstructure value" {
+			t.Errorf("Field1 = %v, want 'mapstructure value'", output.Field1)
+		}
+		if output.Field2 != 999 {
+			t.Errorf("Field2 = %v, want 999", output.Field2)
+		}
+	})
+
+	t.Run("mixed_tags_salesforce_and_mapstructure", func(t *testing.T) {
+		type TestStruct struct {
+			Field1 string `salesforce:"sfField"`
+			Field2 int    `                     mapstructure:"mapField"`
+		}
+
+		input := map[string]any{
+			"sfField":  "salesforce field",
+			"mapField": 123,
+		}
+
+		var output TestStruct
+		err := mapstructureDecode(input, &output, "salesforce")
+		if err != nil {
+			t.Errorf("mapstructureDecode() error = %v", err)
+			return
+		}
+
+		if output.Field1 != "salesforce field" {
+			t.Errorf("Field1 = %v, want 'salesforce field'", output.Field1)
+		}
+		if output.Field2 != 123 {
+			t.Errorf("Field2 = %v, want 123", output.Field2)
+		}
+	})
+
+	t.Run("custom_tag_with_mapstructure_fallback", func(t *testing.T) {
+		type TestStruct struct {
+			Field1 string `json:"jsonField"`
+			Field2 int    `                 mapstructure:"mapField"`
+		}
+
+		input := map[string]any{
+			"jsonField": "json value",
+			"mapField":  456,
+		}
+
+		var output TestStruct
+		err := mapstructureDecode(input, &output, "json")
+		if err != nil {
+			t.Errorf("mapstructureDecode() error = %v", err)
+			return
+		}
+
+		if output.Field1 != "json value" {
+			t.Errorf("Field1 = %v, want 'json value'", output.Field1)
+		}
+		if output.Field2 != 456 {
+			t.Errorf("Field2 = %v, want 456", output.Field2)
+		}
+	})
 }

--- a/iterator.go
+++ b/iterator.go
@@ -82,6 +82,8 @@ func (it *bulkJobQueryIterator) Decode(val any) error {
 		return fmt.Errorf("NewDecoder: %w", err)
 	}
 
+	dec.Tag = it.config.tagName
+
 	if err := dec.Decode(val); err != nil && err != io.EOF {
 		return fmt.Errorf("Decode: %w", err)
 	}

--- a/query.go
+++ b/query.go
@@ -55,7 +55,7 @@ func performQuery(sf *Salesforce, query string, sObject any) error {
 		}
 	}
 
-	sObjectError := mapstructureDecode(queryResp.Records, sObject)
+	sObjectError := mapstructureDecode(queryResp.Records, sObject, sf.config.tagName)
 	if sObjectError != nil {
 		return sObjectError
 	}

--- a/salesforce_test.go
+++ b/salesforce_test.go
@@ -3653,7 +3653,7 @@ func TestSalesforce_CreateQueryBulkJob(t *testing.T) {
 	}
 
 	type data struct {
-		Col string `csv:"col"`
+		Col string `salesforce:"col"`
 	}
 
 	type args struct {


### PR DESCRIPTION
# Support Custom Tags for Mapstructure and CSV Decoding

## Description

This PR introduces the ability to configure a customizable struct tag for decoding methods.

Previously, `go-salesforce` enforced `salesforce` mappings alongside [mapstructure](cci:1://file:///d:/Developments/go-salesforce/dml.go:465:0-483:1) for DML objects while hardcoding [csv](cci:1://file:///d:/Developments/go-salesforce/bulk.go:386:0-404:1) tags for [iterator.go](cci:7://file:///d:/Developments/go-salesforce/iterator.go:0:0-0:0) functionality. This feature standardizes the tags utilized by [mapstructure](cci:1://file:///d:/Developments/go-salesforce/dml.go:465:0-483:1) and `csvutil` inside the library and enables consumers to override the default tag of `"salesforce"` should their project prefer a different naming scheme or require alternative configuration mappings.

## Changes Made
- Introduced a new [WithTagName()](cci:1://file:///d:/Developments/go-salesforce/config.go:155:0-164:1) functional option to [config.go](cci:7://file:///d:/Developments/go-salesforce/config.go:0:0-0:0) alongside `tagConfig string`.
- Standardized iterator decoding (inside [iterator.go](cci:7://file:///d:/Developments/go-salesforce/iterator.go:0:0-0:0)) to inject `dec.Tag = sf.config.tagName` down to `csvutil`.
- Replaced hardcoded tag injections with `tagName + ",mapstructure"` dynamically using the configured string inside [dml.go](cci:7://file:///d:/Developments/go-salesforce/dml.go:0:0-0:0).
- Restructured [convertToMap](cci:1://file:///d:/Developments/go-salesforce/dml.go:18:0-29:1) and [convertToSliceOfMaps](cci:1://file:///d:/Developments/go-salesforce/dml.go:31:0-42:1) arguments to pipe down the newly configurable field.
- Updated [doInsertOne](cci:1://file:///d:/Developments/go-salesforce/dml.go:182:0-213:1), [doUpdateOne](cci:1://file:///d:/Developments/go-salesforce/dml.go:215:0-246:1), [doDeleteComposite](cci:1://file:///d:/Developments/go-salesforce/composite.go:249:0-308:1), [doBulkJob](cci:1://file:///d:/Developments/go-salesforce/bulk.go:474:0-533:1), [performQuery](cci:1://file:///d:/Developments/go-salesforce/query.go:17:0-63:1) and other dependent data-structural processing commands to carry the argument.
- Corrected occurrences of `csv:` and updated documentation in [README.md](cci:7://file:///d:/Developments/go-salesforce/README.md:0:0-0:0) to indicate usage of configurable mapped tags (default `"salesforce"`).
- Addressed internal unit testing functions [convertToMap](cci:1://file:///d:/Developments/go-salesforce/dml.go:18:0-29:1) passing the fallback schema explicitly.

## Testing and Verification
- Hand-tested iteration via [QueryBulkIterator](cci:1://file:///d:/Developments/go-salesforce/salesforce.go:479:0-502:1) ensuring the expected test inputs evaluated appropriately against an unexported struct mock tracking `salesforce:"col"` tags against generic test columns. 
- Full test suite `go test ./...` exits clean (Status: PASS).
