### PR TITLE
Fix: convertToString  to support pointer values

### DIFF
--- a/dml.go
+++ b/dml.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"reflect"
 	"strconv"
 
 	"github.com/go-viper/mapstructure/v2"
@@ -157,6 +158,12 @@ func checkForExternalId(
 }
 
 func convertToString(value any) (string, bool) {
+	// Handle pointers
+	v := reflect.Indirect(reflect.ValueOf(value))
+	if !v.IsValid() {
+		return "", false
+	}
+	value = v.Interface()
 	switch typedValue := value.(type) {
 	case int:
 		if typedValue == 0 {

--- a/dml_test.go
+++ b/dml_test.go
@@ -998,3 +998,44 @@ func Test_doDeleteCollection(t *testing.T) {
 		})
 	}
 }
+
+func Test_convertToString(t *testing.T) {
+	strVal := "test"
+	intVal := 123
+	int64Val := int64(123)
+	floatVal := 123.45
+
+	tests := []struct {
+		name      string
+		value     any
+		wantStr   string
+		wantValid bool
+	}{
+		{"string", "test", "test", true},
+		{"int", 123, "123", true},
+		{"int64", int64(123), "123", true},
+		{"float64", 123.45, "123.45", true},
+		{"zero int", 0, "", false},
+		{"zero int64", int64(0), "", false},
+		{"zero float64", float64(0), "", false},
+		{"pointer to string", &strVal, "test", true},
+		{"pointer to int", &intVal, "123", true},
+		{"pointer to int64", &int64Val, "123", true},
+		{"pointer to float64", &floatVal, "123.45", true},
+		{"nil", nil, "", false},
+		{"nil pointer", (*string)(nil), "", false},
+		{"unsupported type", []string{}, "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotStr, gotValid := convertToString(tt.value)
+			if gotStr != tt.wantStr {
+				t.Errorf("convertToString() gotStr = %v, want %v", gotStr, tt.wantStr)
+			}
+			if gotValid != tt.wantValid {
+				t.Errorf("convertToString() gotValid = %v, want %v", gotValid, tt.wantValid)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixed a bug in convertToString where pointer values (e.g., `*string`, `*int`) would fail to evaluate correctly and return empty strings.
### **Changes:**
- Added `reflect.Indirect` to automatically dereference pointers before type evaluation. 
- Included safety checks to gracefully handle `nil` pointers without panicking.
- Added comprehensive unit tests in dml_test.go to cover pointer and `nil` value scenarios.