### PR TITLE
Stop treating 3XX response codes as errors in doRequest

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -339,7 +339,8 @@ func collectQueryResults(sf *Salesforce, bulkJobId string) ([][]string, error) {
 		}
 		records = append(
 			records,
-			queryResults.Data[1:]...) // don't include headers in subsequent batches
+			queryResults.Data[1:]...,
+		) // don't include headers in subsequent batches
 	}
 	return records, nil
 }

--- a/examples/functional-config/main.go
+++ b/examples/functional-config/main.go
@@ -34,7 +34,8 @@ func main() {
 	fmt.Printf("Auth Flow: %s\n", sf.GetAuthFlow())
 
 	// Example with custom configuration using functional options
-	sfCustom, err := salesforce.Init(creds,
+	sfCustom, err := salesforce.Init(
+		creds,
 		salesforce.WithAPIVersion("v58.0"),
 		salesforce.WithBatchSizeMax(150),
 		salesforce.WithBulkBatchSizeMax(8000),
@@ -53,7 +54,8 @@ func main() {
 	fmt.Printf("Auth Flow: %s\n", sfCustom.GetAuthFlow())
 
 	// Example with error handling in functional options
-	_, err = salesforce.Init(creds,
+	_, err = salesforce.Init(
+		creds,
 		salesforce.WithAPIVersion(""), // This will cause an error
 	)
 	if err != nil {
@@ -61,7 +63,8 @@ func main() {
 	}
 
 	// Example with invalid batch size
-	_, err = salesforce.Init(creds,
+	_, err = salesforce.Init(
+		creds,
 		salesforce.WithBatchSizeMax(300), // This will cause an error (max is 200)
 	)
 	if err != nil {

--- a/examples/http-config/main.go
+++ b/examples/http-config/main.go
@@ -23,7 +23,8 @@ func main() {
 	}
 
 	// Initialize Salesforce client with custom HTTP client
-	sf, err := salesforce.Init(creds,
+	sf, err := salesforce.Init(
+		creds,
 		salesforce.WithRoundTripper(&http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: false, // Set to true if you need to skip SSL verification
@@ -53,7 +54,8 @@ func main() {
 		MaxIdleConnsPerHost: 5,
 	}
 
-	sf2, err := salesforce.Init(creds,
+	sf2, err := salesforce.Init(
+		creds,
 		salesforce.WithRoundTripper(customRoundTripper),
 		salesforce.WithAPIVersion("v64.0"),
 	)
@@ -75,7 +77,8 @@ func main() {
 	fmt.Printf("Compression headers enabled: %v\n", sf3.GetCompressionHeaders())
 
 	// Example of combining multiple configuration options
-	sf4, err := salesforce.Init(creds,
+	sf4, err := salesforce.Init(
+		creds,
 		salesforce.WithRoundTripper(http.DefaultTransport),
 		salesforce.WithCompressionHeaders(true),
 		salesforce.WithAPIVersion("v65.0"),

--- a/requests.go
+++ b/requests.go
@@ -75,7 +75,7 @@ func doRequest(
 	if err != nil {
 		return resp, err
 	}
-	if resp.StatusCode < 200 || resp.StatusCode > 300 {
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
 		resp, err = processSalesforceError(*resp, auth, config, payload)
 		if err != nil {
 			return resp, err

--- a/requests_test.go
+++ b/requests_test.go
@@ -28,6 +28,12 @@ func Test_doRequest(t *testing.T) {
 	compressedServer, sfAuthCompressed := setupTestServer("test", http.StatusOK)
 	defer compressedServer.Close()
 
+	serverWith304Resp, authWith304Resp := setupTestServer(
+		"",
+		http.StatusNotModified,
+	)
+	defer serverWith304Resp.Close()
+
 	type args struct {
 		auth    *authentication
 		payload requestPayload
@@ -93,6 +99,23 @@ func Test_doRequest(t *testing.T) {
 				},
 			},
 			want:    http.StatusOK,
+			wantErr: false,
+		},
+		{
+			name: "handle_not_modified_statusCode_304",
+			args: args{
+				auth: &authWith304Resp,
+				payload: requestPayload{
+					method:  http.MethodGet,
+					uri:     "/sobjects/Account/describe",
+					content: jsonType,
+					body:    "",
+					options: []RequestOption{
+						WithHeader("If-Modified-Since", "Wed, 21 Oct 2015 07:28:00 GMT"),
+					},
+				},
+			},
+			want:    http.StatusNotModified,
 			wantErr: false,
 		},
 	}

--- a/salesforce_test.go
+++ b/salesforce_test.go
@@ -428,9 +428,10 @@ func Test_validateCollections(t *testing.T) {
 		{
 			name: "validation_success",
 			args: args{
-				sf: *buildSalesforceStruct(&authentication{
-					AccessToken: "1234",
-				},
+				sf: *buildSalesforceStruct(
+					&authentication{
+						AccessToken: "1234",
+					},
 				),
 				records:   []account{},
 				batchSize: 200,
@@ -591,9 +592,10 @@ func Test_validateBulk(t *testing.T) {
 		{
 			name: "validation_success_assignment_case",
 			args: args{
-				sf: *buildSalesforceStruct(&authentication{
-					AccessToken: "1234",
-				},
+				sf: *buildSalesforceStruct(
+					&authentication{
+						AccessToken: "1234",
+					},
 				),
 
 				records:          nil,


### PR DESCRIPTION
### Context

https://github.com/k-capehart/go-salesforce/issues/149

### Changes
- Change conditional to no longer treat 3XX response codes as errors.
- Add test for specific 304 case as that's the most likely scenario we would encounter as most 3XX responses are automatically handle by the Go HTTP library.